### PR TITLE
change any {.*} => {name} to work around different names in different APIs for the same resource

### DIFF
--- a/ng/manage.ts
+++ b/ng/manage.ts
@@ -1017,6 +1017,7 @@ angular.module("armExplorer", ["ngRoute", "ngAnimate", "ngSanitize", "ui.bootstr
 
     function buildResourcesDefinitionsTable(operation: IMetadataObject, url?: string) {
         url = (operation ? operation.Url : url);
+        url = url.replace(/{.*?}/g, "{name}");
         var segments = url.split("/").filter(a => a.length !== 0);
         var resourceName = segments.pop();
         var addedElement: IResourceDefinition;


### PR DESCRIPTION
Fixes #73 

The change is very simple. This is easier that changing the logic that builds the metadata tree to handle any `{.*}` as the same in any url segment.

/cc @shobak101 @davidebbo 