### PR TITLE
Fix duplicate -ResourceName in CREATE cmdlet

### DIFF
--- a/ng/models/ISelectHandlerReturn.ts
+++ b/ng/models/ISelectHandlerReturn.ts
@@ -1,4 +1,4 @@
-﻿interface ISelelctHandlerReturn {
+﻿interface ISelectHandlerReturn {
     resourceDefinition: IResourceDefinition;
     data: any;
     url: string;


### PR DESCRIPTION
- Fixed duplicate `-ResourceName` in CREATE PowerShell cmdlet (https://github.com/projectkudu/ARMExplorer/issues/117)
- Fixed camelCase for function names (i will rename them back if there's a reason for the inconsistency)
- Fixed typo `ISelelctHandlerReturn` &rarr; `ISelectHandlerReturn`

**I'm considering this work in progress** since i'm not entirely happy with my backwards approach (we're still getting both resource Name and Type and then subtracting from the result based on an optional parameter).

Perhaps a better approach would be to split [`getResourceTypeAndName()` ](https://github.com/projectkudu/ARMExplorer/blob/snobu-resnamefix/ng/manage.ts#L1686), but that would result in a good chunk of repeated code for splitting segments and whatnot..