### PR TITLE
Fix powershell RM cmdlet generation and add some unittests

### DIFF
--- a/ARMExplorer.csproj
+++ b/ARMExplorer.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="packages\Microsoft.TypeScript.MSBuild.2.2.2\build\Microsoft.TypeScript.MSBuild.props" Condition="Exists('packages\Microsoft.TypeScript.MSBuild.2.2.2\build\Microsoft.TypeScript.MSBuild.props')" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.Default.props" Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.Default.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -21,7 +22,8 @@
     <IISExpressWindowsAuthentication>disabled</IISExpressWindowsAuthentication>
     <IISExpressUseClassicPipelineMode>false</IISExpressUseClassicPipelineMode>
     <TypeScriptToolsVersion>2.1</TypeScriptToolsVersion>
-    <NuGetPackageImportStamp>86a6151d</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
     <UseGlobalApplicationHostFile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -32,6 +34,19 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TypeScriptTarget>ES5</TypeScriptTarget>
+    <TypeScriptJSXEmit>None</TypeScriptJSXEmit>
+    <TypeScriptCompileOnSaveEnabled>True</TypeScriptCompileOnSaveEnabled>
+    <TypeScriptNoImplicitAny>False</TypeScriptNoImplicitAny>
+    <TypeScriptModuleKind>None</TypeScriptModuleKind>
+    <TypeScriptRemoveComments>True</TypeScriptRemoveComments>
+    <TypeScriptOutFile>ng/manage.js</TypeScriptOutFile>
+    <TypeScriptOutDir />
+    <TypeScriptGeneratesDeclarations>False</TypeScriptGeneratesDeclarations>
+    <TypeScriptNoEmitOnError>True</TypeScriptNoEmitOnError>
+    <TypeScriptSourceMap>False</TypeScriptSourceMap>
+    <TypeScriptMapRoot />
+    <TypeScriptSourceRoot />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -171,6 +186,7 @@
   </ItemGroup>
   <ItemGroup>
     <TypeScriptCompile Include="ng\manage.ts" />
+    <TypeScriptCompile Include="ng\PowerShellScriptGenerator.ts" />
     <TypeScriptCompile Include="ng\models\IAction.ts" />
     <TypeScriptCompile Include="ng\models\IArmTreeScope.ts" />
     <TypeScriptCompile Include="ng\models\IMetadataObject.ts" />
@@ -181,6 +197,7 @@
     <TypeScriptCompile Include="ng\models\ITreeBranch.ts" />
     <TypeScriptCompile Include="ng\models\ITreeControl.ts" />
     <TypeScriptCompile Include="ng\polyfill.ts" />
+    <TypeScriptCompile Include="ng\angularPolyfill.ts" />
     <TypeScriptCompile Include="ng\typings\ace\ace.d.ts" />
     <TypeScriptCompile Include="ng\typings\angularjs\angular-animate.d.ts" />
     <TypeScriptCompile Include="ng\typings\angularjs\angular-cookies.d.ts" />
@@ -193,7 +210,9 @@
     <TypeScriptCompile Include="ng\typings\jquery.cookie\jquery.cookie.d.ts" />
     <TypeScriptCompile Include="ng\typings\jquery\jquery.d.ts" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Folder Include="ng\test\" />
+  </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
@@ -232,9 +251,12 @@
     </PropertyGroup>
     <Error Condition="!Exists('packages\Microsoft.ApplicationInsights.Agent.Intercept.0.17.0\build\Microsoft.ApplicationInsights.Agent.Intercept.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.ApplicationInsights.Agent.Intercept.0.17.0\build\Microsoft.ApplicationInsights.Agent.Intercept.targets'))" />
     <Error Condition="!Exists('packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
+    <Error Condition="!Exists('packages\Microsoft.TypeScript.MSBuild.2.2.2\build\Microsoft.TypeScript.MSBuild.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.TypeScript.MSBuild.2.2.2\build\Microsoft.TypeScript.MSBuild.props'))" />
+    <Error Condition="!Exists('packages\Microsoft.TypeScript.MSBuild.2.2.2\build\Microsoft.TypeScript.MSBuild.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.TypeScript.MSBuild.2.2.2\build\Microsoft.TypeScript.MSBuild.targets'))" />
   </Target>
   <Import Project="packages\Microsoft.ApplicationInsights.Agent.Intercept.0.17.0\build\Microsoft.ApplicationInsights.Agent.Intercept.targets" Condition="Exists('packages\Microsoft.ApplicationInsights.Agent.Intercept.0.17.0\build\Microsoft.ApplicationInsights.Agent.Intercept.targets')" />
   <Import Project="packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
+  <Import Project="packages\Microsoft.TypeScript.MSBuild.2.2.2\build\Microsoft.TypeScript.MSBuild.targets" Condition="Exists('packages\Microsoft.TypeScript.MSBuild.2.2.2\build\Microsoft.TypeScript.MSBuild.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This project has dependencies on OAuth authentication.
 1. Select `Add an application my organization is developing`
 1. Enter any name for application name.
 1. Select `WEB APPLICATION AND/OR WEB API`
-1. Enter `https://localhost:44306/` as `SIGN ON URL` 
+1. Enter `https://localhost:44306/` as `SIGN ON URL`
 1. For `APP ID URL`, enter something like `https://davidebboslingshot.onmicrosoft.com/`.
 1. Once created, click `CONFIGURE` tab
 1. On `Permission to other applications`, add `Windows Azure Service Management API` and check `Access Azure Service Management` for `Delegated Permissions` and save.
@@ -21,7 +21,7 @@ This project has dependencies on OAuth authentication.
 
 
 Test with localhost
-1. In VS, make Slingshot.Api the starter project. The RedirectionSite project can be ignored.
+1. Build the solution using VS.
 1. Starting running it in the debugger (F5).
 1. In browser, it should redirect to login page.
 1. Enter AAD account and password.
@@ -32,7 +32,7 @@ Test with localhost
 ### Test ARM apis
 1. `https://localhost:44306/api/token` - show current token details.
 2. `https://localhost:44306/api/tenants` - show all tenants (AAD directory) user belongs to.
-3. and so on.. 
+3. and so on..
 
 ### Test with Azure Websites
 1. Create Azure Websites with local git publishing enabled
@@ -40,6 +40,13 @@ Test with localhost
 3. Deploy the website by pushing the repository
 4. Set AADClientID and AADClientSecret appSettings
 5. To test, simply browse to the website and append the query string "?repository=<url of your Git repository>"
+
+### Running unit tests
+1. Unit test support is still evolving and the tests are located under ng\test directory.
+2. Tests are built using tsconfig.json file under ng folder.
+3. You will need to have tsc and node installed before you can run the tests. You can use npm for this.
+4. Navigate to ng directory and compile the files using 'tsc' and run the tests using 'node manageWithTests.js'
+5. Remember to update the tsconfig.json file when adding new test files.
 
 ## Adding Swagger based specs
 
@@ -52,4 +59,3 @@ copy [Path to swagger spec]
 Hack: Edit the swagger and delete the CollectionApiVersions array at the very end, which somehow kills the parser!
 node ConvertSwaggerToExplorerSpecs.js Service.json > ..\App_Data\JsonSpecs\Microsoft.Web.json
 ```
-

--- a/ng/PowerShellScriptGenerator.ts
+++ b/ng/PowerShellScriptGenerator.ts
@@ -1,0 +1,475 @@
+﻿module armExplorer {
+
+    enum ResourceActions {
+        PATCH,
+        PUT,
+        GET,
+        CREATE
+    }
+
+    enum HttpVerb {
+        GET,
+        POST,
+        DELETE
+    }
+
+    function GETPSObjectFromJSON(json: string, nestingLevel: number): string {
+        var tabs = "";
+        for (var i = 0; i < nestingLevel; i++) {
+            tabs += "\t";
+        }
+        var jsonObj = JSON.parse(json);
+        if (typeof jsonObj === "string") {
+            return "\"" + jsonObj + "\"";
+        }
+        else if (typeof jsonObj === "boolean") {
+            return jsonObj.toString();
+        }
+        else if (typeof jsonObj === "number") {
+            return jsonObj.toString();
+        }
+        else if (Array.isArray(jsonObj)) {
+            var result = "(\n";
+            for (var i = 0; i < jsonObj.length; i++) {
+                result += tabs + "\t" + GETPSObjectFromJSON(JSON.stringify(jsonObj[i]), nestingLevel + 1) + "\n";
+            }
+            return result + tabs + ")";
+        }
+        else if (typeof jsonObj === "object") {
+            var result = "@{\n";
+            for (var prop in jsonObj) {
+                if (jsonObj.hasOwnProperty(prop)) {
+                    result += tabs + "\t" + prop + " = " + GETPSObjectFromJSON(JSON.stringify(jsonObj[prop]), nestingLevel + 1) + "\n";
+                }
+            }
+            return result + tabs + "}\n";
+        }
+        return json;
+    }
+
+    enum RMURLPARTS {
+        Protocol,
+        Blank,
+        DomainName,
+        SubscriptionsKey,
+        SubscriptionsValue,
+        ResourceGroupsKey,
+        ResourceGroupsValue, // Urls with length <= ResourceGroupsValue will only include resourceId
+        ProviderKey,
+        ProviderValue, // start of resourcetype followed by 9(ResourceType1Name) , 11, 13, ... ( 8, 9 will always exist, 11, 13.. is optional)
+        ResourceType1Name,
+        ResourceType1Value // start of resourcename followed by 12, 14,...(12, 14,... is optional)
+    }
+
+    export class ARMUrlParser {
+        private originalUrl: string = "";
+        private url: string = "";
+        private urlParts: Array<string> = [];
+
+        constructor(private value: ISelectHandlerReturn, private actions: IAction[]) {
+            this.url = value.url;
+            this.originalUrl = value.url;
+            if (this.isSecureGet(this.value.httpMethod, this.url)) {
+                this.url = this.value.url.replace("/list", ""); // ignore /list since it is not part of resource url
+            }
+            this.urlParts = this.url.split("/");
+        }
+
+        private isSecureGet(httpMethod: string, url: string): boolean {
+            // sample url "https://management.azure.com/subscriptions/0000000-0000-0000-0000-0000000000000/resourceGroups/rgrp1/providers/Microsoft.Web/sites/WebApp120170517014339/config/appsettings/list"
+            return (httpMethod.toLowerCase() === HttpVerb[HttpVerb.POST].toLowerCase()) && url.toLowerCase().endsWith("/list")
+        }
+
+        private hasResourceType(): boolean {
+            return this.urlParts.length > RMURLPARTS.ResourceType1Name;
+        }
+
+        private hasResourceName(): boolean {
+            return this.urlParts.length > RMURLPARTS.ResourceType1Value;
+        }
+
+        getAPIVersion(): string {
+            return this.value.resourceDefinition.apiVersion;
+        }
+
+        getURL(): string {
+            return this.value.url;
+        }
+
+        getResourceDefinitionChildren(): string|string[] {
+            return this.value.resourceDefinition.children;
+        }
+
+        getOriginalURL(): string {
+            return this.originalUrl;
+        }
+
+        getHttpMethod(): string {
+            return this.value.httpMethod;
+        }
+
+        getActions(): IAction[] {
+            return this.actions;
+        }
+
+        getResourceActions(): string[]{
+            return this.value.resourceDefinition.actions;
+        }
+
+        hasResourceProvider(): boolean {
+            return this.urlParts.length > RMURLPARTS.ProviderKey;
+        }
+
+        isResourceGroupURL(): boolean {
+            return this.urlParts.length === (RMURLPARTS.ResourceGroupsKey + 1);
+        }
+
+        getResourceIdentifier(): ResourceIdentifier {
+            let resourceIdentifier = {} as ResourceIdentifier;
+
+            if (!this.hasResourceType()) {
+                // We only have resource Id
+                resourceIdentifier.resourceIdentifierType = ResourceIdentifierType.WithIDOnly;
+                resourceIdentifier.resourceId = this.url.replace("https://management.azure.com", "");
+            }
+            else {
+                resourceIdentifier.resourceGroup = this.urlParts[RMURLPARTS.ResourceGroupsValue];
+                resourceIdentifier.resourceType = this.urlParts[RMURLPARTS.ProviderValue] + "/" + this.urlParts[RMURLPARTS.ResourceType1Name];
+                resourceIdentifier.resourceIdentifierType = ResourceIdentifierType.WithGroupType;
+
+                if (this.hasResourceName()) {
+                    resourceIdentifier.resourceName = this.urlParts[RMURLPARTS.ResourceType1Value];
+                    resourceIdentifier.resourceIdentifierType = ResourceIdentifierType.WithGroupTypeName;
+                }
+                // check for resource sub types
+                for (let i = RMURLPARTS.ResourceType1Value + 1; i < this.urlParts.length; i++) {
+                    if (i % 2 == 1) {
+                        resourceIdentifier.resourceType += ("/" + this.urlParts[i]);
+                    }
+                    else {
+                        resourceIdentifier.resourceName += ("/" + this.urlParts[i]);
+                    }
+                }
+            }
+            return resourceIdentifier;
+        }
+    }
+
+    export class PsScriptGenerator {
+        private script: string = "";
+        private actionsIndex: number = 0;
+        constructor(private resolver: PSCmdletParameterResolver) {
+        }
+
+        private getPrefix(commandInfo: RMCommandInfo): string {
+            let prefixString: string = "";
+            switch (commandInfo.cmd) {
+                case CmdType.Get: {
+                    prefixString = '# GET ' + this.resolver.getActionName() + "\n";
+                    break;
+                }
+                case CmdType.NewResourceGroup: {
+                    prefixString += '# CREATE ' + this.resolver.getActionName() +"\n";
+                    prefixString += '$ResourceLocation = "West US"\n';
+                    prefixString += '$ResourceName = "NewresourceGroup"\n\n';
+                    break;
+                }
+                case CmdType.RemoveAction: {
+                    prefixString = `# DELETE ${this.resolver.getActionNameFromAction(this.actionsIndex)}\n`;
+                    break;
+                }
+                case CmdType.Set: {
+                    prefixString = `# SET ${this.resolver.getActionNameFromList()}\n$PropertiesObject = @{\n\t#Property = value;\n}\n`;
+                    break;
+                }
+                case CmdType.Invoke:
+                case CmdType.InvokeAction: {
+                    if (commandInfo.isAction) {
+                        let currentAction: IAction = this.resolver.getActionParameters(this.actionsIndex);
+                        let parametersObject: string = currentAction.requestBody ? (`$ParametersObject = ${GETPSObjectFromJSON(currentAction.requestBody, 0)}\n`) : '';
+                        prefixString = `# Action ${this.resolver.getActionNameFromAction(this.actionsIndex)}\n${parametersObject}`;
+                    }
+                    else {
+                        prefixString = `# LIST ${this.resolver.getActionNameFromList()}\n`;
+                    }
+                    break;
+                }
+                case CmdType.New: {
+                    if (commandInfo.isSetAction) {
+                        prefixString = `# SET ${this.resolver.getActionName()}\n$PropertiesObject = @{\n\t#Property = value;\n}\n`;
+                    }
+                    else {
+                        let newName: string = "New" + this.resolver.getResourceName();
+                        prefixString = `# CREATE ${this.resolver.getActionName()}\n$ResourceLocation = "West US"\n$ResourceName = "${newName}"\n$PropertiesObject = @{\n\t#Property = value;\n}\n`;
+                    }
+                    break;
+                }
+            }
+            return prefixString;
+        }
+
+        getScript(cmdActionPair: RMCommandInfo): string {
+            let cmdParameters = this.resolver.getParameters();
+            let currentScript: string = "";
+            let scriptPrefix: string = this.getPrefix(cmdActionPair);
+
+            switch (cmdActionPair.cmd) {
+                case CmdType.Get: {
+                    switch (cmdParameters.resourceIdentifier.resourceIdentifierType) {
+                        case ResourceIdentifierType.WithIDOnly: {
+                            if (cmdParameters.isCollection) {
+                                currentScript = `${cmdActionPair.cmd} -ResourceId ${cmdParameters.resourceIdentifier.resourceId} -IsCollection -ApiVersion ${cmdParameters.apiVersion}`;
+                            }
+                            else {
+                                currentScript = `${cmdActionPair.cmd} -ResourceId ${cmdParameters.resourceIdentifier.resourceId} -ApiVersion ${cmdParameters.apiVersion}`;
+                            }
+                            break;
+                        }
+                        case ResourceIdentifierType.WithGroupType: {
+                            if (cmdParameters.isCollection) {
+                                currentScript = `${cmdActionPair.cmd} -ResourceGroupName ${cmdParameters.resourceIdentifier.resourceGroup} -ResourceType ${cmdParameters.resourceIdentifier.resourceType} -IsCollection -ApiVersion ${cmdParameters.apiVersion}`;
+                            }
+                            else {
+                                currentScript = `${cmdActionPair.cmd} -ResourceGroupName ${cmdParameters.resourceIdentifier.resourceGroup} -ResourceType ${cmdParameters.resourceIdentifier.resourceType} -ApiVersion ${cmdParameters.apiVersion}`;
+                            }
+
+                            break;
+                        }
+                        case ResourceIdentifierType.WithGroupTypeName: {
+
+                            if (cmdParameters.isCollection) {
+                                currentScript = `${cmdActionPair.cmd} -ResourceGroupName ${cmdParameters.resourceIdentifier.resourceGroup} -ResourceType ${cmdParameters.resourceIdentifier.resourceType} -ResourceName "${cmdParameters.resourceIdentifier.resourceName}" -IsCollection -ApiVersion ${cmdParameters.apiVersion}`;
+                            }
+                            else {
+                                currentScript = `${cmdActionPair.cmd} -ResourceGroupName ${cmdParameters.resourceIdentifier.resourceGroup} -ResourceType ${cmdParameters.resourceIdentifier.resourceType} -ResourceName "${cmdParameters.resourceIdentifier.resourceName}" -ApiVersion ${cmdParameters.apiVersion}`;
+                            }
+                            break;
+                        }
+                    }
+                    break;
+                }
+                case CmdType.New: {
+                    if (cmdActionPair.isSetAction) {
+                        switch (cmdParameters.resourceIdentifier.resourceIdentifierType) {
+                            case ResourceIdentifierType.WithIDOnly: {
+                                // don't think is possible. 
+                                console.log("Attempt to create resource with pre existing id");
+                                break;
+                            }
+                            case ResourceIdentifierType.WithGroupType: {
+                                currentScript = `${cmdActionPair.cmd} -PropertyObject $PropertiesObject -ResourceGroupName ${cmdParameters.resourceIdentifier.resourceGroup} -ResourceType ${cmdParameters.resourceIdentifier.resourceType} -ApiVersion ${cmdParameters.apiVersion} -Force`;
+                                break;
+                            }
+                            case ResourceIdentifierType.WithGroupTypeName: {
+                                currentScript = `${cmdActionPair.cmd} -PropertyObject $PropertiesObject -ResourceGroupName ${cmdParameters.resourceIdentifier.resourceGroup} -ResourceType ${cmdParameters.resourceIdentifier.resourceType} -ResourceName "${cmdParameters.resourceIdentifier.resourceName}" -ApiVersion ${cmdParameters.apiVersion} -Force`;
+                                break;
+                            }
+                        }
+                    }
+                    else {
+                        switch (cmdParameters.resourceIdentifier.resourceIdentifierType) {
+                            case ResourceIdentifierType.WithIDOnly: {
+                                // don't think is possible. 
+                                console.log("Attempt to create resource with pre existing id");
+                                break;
+                            }
+                            case ResourceIdentifierType.WithGroupType: {
+                                currentScript = `${cmdActionPair.cmd} -ResourceName $ResourceName -Location $ResourceLocation -PropertyObject $PropertiesObject -ResourceGroupName ${cmdParameters.resourceIdentifier.resourceGroup} -ResourceType ${cmdParameters.resourceIdentifier.resourceType} -ApiVersion ${cmdParameters.apiVersion} -Force`;
+                                break;
+                            }
+                            case ResourceIdentifierType.WithGroupTypeName: {
+                                currentScript = `${cmdActionPair.cmd} -Location $ResourceLocation -PropertyObject $PropertiesObject -ResourceGroupName ${cmdParameters.resourceIdentifier.resourceGroup} -ResourceType ${cmdParameters.resourceIdentifier.resourceType} -ResourceName "${cmdParameters.resourceIdentifier.resourceName}/$ResourceName" -ApiVersion ${cmdParameters.apiVersion} -Force`;
+                                break;
+                            }
+                        }
+                    }
+                    break;
+                }
+                case CmdType.Set: {
+                    switch (cmdParameters.resourceIdentifier.resourceIdentifierType) {
+                        case ResourceIdentifierType.WithIDOnly: {
+                            currentScript = `${cmdActionPair.cmd} -PropertyObject $PropertiesObject -ResourceId ${cmdParameters.resourceIdentifier.resourceId} -ApiVersion ${cmdParameters.apiVersion} -Force`;
+                            break;
+                        }
+                        case ResourceIdentifierType.WithGroupType: {
+                            currentScript = `${cmdActionPair.cmd} -PropertyObject $PropertiesObject -ResourceGroupName ${cmdParameters.resourceIdentifier.resourceGroup} -ResourceType ${cmdParameters.resourceIdentifier.resourceType} -ApiVersion ${cmdParameters.apiVersion} -Force`;
+                            break;
+                        }
+                        case ResourceIdentifierType.WithGroupTypeName: {
+                            currentScript = `${cmdActionPair.cmd} -PropertyObject $PropertiesObject -ResourceGroupName ${cmdParameters.resourceIdentifier.resourceGroup} -ResourceType ${cmdParameters.resourceIdentifier.resourceType} -ResourceName "${cmdParameters.resourceIdentifier.resourceName}" -ApiVersion ${cmdParameters.apiVersion} -Force`;
+                            break;
+                        }
+                    }
+                    break;
+                }
+
+                case CmdType.RemoveAction: {
+                    switch (cmdParameters.resourceIdentifier.resourceIdentifierType) {
+                        case ResourceIdentifierType.WithIDOnly: {
+                            currentScript = `${cmdActionPair.cmd} -ResourceId ${cmdParameters.resourceIdentifier.resourceId} -ApiVersion ${cmdParameters.apiVersion} -Force`;
+                            break;
+                        }
+                        case ResourceIdentifierType.WithGroupType: {
+                            currentScript = `${cmdActionPair.cmd} -ResourceGroupName ${cmdParameters.resourceIdentifier.resourceGroup} -ResourceType ${cmdParameters.resourceIdentifier.resourceType} -ApiVersion ${cmdParameters.apiVersion} -Force`;
+                            break;
+                        }
+                        case ResourceIdentifierType.WithGroupTypeName: {
+                            currentScript = `${cmdActionPair.cmd} -ResourceGroupName ${cmdParameters.resourceIdentifier.resourceGroup} -ResourceType ${cmdParameters.resourceIdentifier.resourceType} -ResourceName "${cmdParameters.resourceIdentifier.resourceName}" -ApiVersion ${cmdParameters.apiVersion} -Force`;
+                            break;
+                        }
+                    }
+                    this.actionsIndex++;
+                    break;
+                }
+                case CmdType.Invoke:
+                case CmdType.InvokeAction: {
+                    if (cmdActionPair.isAction) {
+                        let currentAction: IAction = this.resolver.getActionParameters(this.actionsIndex++);
+                        let parameters: string = currentAction.requestBody ? "-Parameters $ParametersObject" : "";
+
+                        switch (cmdParameters.resourceIdentifier.resourceIdentifierType) {
+                            case ResourceIdentifierType.WithIDOnly: {
+                                currentScript = `${cmdActionPair.cmd} -ResourceId ${cmdParameters.resourceIdentifier.resourceId} -Action ${currentAction.name} ${parameters} -ApiVersion ${cmdParameters.apiVersion} -Force`;
+                                break;
+                            }
+                            case ResourceIdentifierType.WithGroupType: {
+                                currentScript = `${cmdActionPair.cmd} -ResourceGroupName ${cmdParameters.resourceIdentifier.resourceGroup} -ResourceType ${cmdParameters.resourceIdentifier.resourceType} -Action ${currentAction.name} ${parameters} -ApiVersion ${cmdParameters.apiVersion} -Force`;
+                                break;
+                            }
+                            case ResourceIdentifierType.WithGroupTypeName: {
+                                currentScript = `${cmdActionPair.cmd} -ResourceGroupName ${cmdParameters.resourceIdentifier.resourceGroup} -ResourceType ${cmdParameters.resourceIdentifier.resourceType} -ResourceName ${cmdParameters.resourceIdentifier.resourceName} -Action ${currentAction.name} ${parameters} -ApiVersion ${cmdParameters.apiVersion} -Force`;
+                                break;
+                            }
+                        }
+                    }
+                    else {
+                        switch (cmdParameters.resourceIdentifier.resourceIdentifierType) {
+                            case ResourceIdentifierType.WithIDOnly: {
+                                currentScript = `$resource = ${cmdActionPair.cmd} -ResourceId ${cmdParameters.resourceIdentifier.resourceId} -Action list -ApiVersion ${cmdParameters.apiVersion} -Force\n$resource.Properties`
+                                break;
+                            }
+                            case ResourceIdentifierType.WithGroupType: {
+                                currentScript = `$resource = ${cmdActionPair.cmd} -ResourceGroupName ${cmdParameters.resourceIdentifier.resourceGroup} -ResourceType ${cmdParameters.resourceIdentifier.resourceType} -Action list -ApiVersion ${cmdParameters.apiVersion} -Force\n$resource.Properties`
+                                break;
+                            }
+                            case ResourceIdentifierType.WithGroupTypeName: {
+                                currentScript = `$resource = ${cmdActionPair.cmd} -ResourceGroupName ${cmdParameters.resourceIdentifier.resourceGroup} -ResourceType ${cmdParameters.resourceIdentifier.resourceType} -ResourceName "${cmdParameters.resourceIdentifier.resourceName}" -Action list -ApiVersion ${cmdParameters.apiVersion} -Force\n$resource.Properties`
+                                break;
+                            }
+                        }
+                    }
+                    break;
+                }
+                
+                case CmdType.NewResourceGroup: {
+                    currentScript += `${cmdActionPair.cmd} -Location $ResourceLocation -Name $ResourceName`;
+                    break;
+                }
+            }
+            return scriptPrefix + currentScript + "\n\n";
+        }
+    }
+
+    export class PSCmdletParameterResolver {
+        private supportedCommands: RMCommandInfo[] = [];
+
+        constructor(private urlParser: ARMUrlParser) {
+            this.fillSupportedCommands();
+        }
+
+        private fillSupportedCommands() {
+            let resourceActions = this.urlParser.getResourceActions();
+
+            // add GET related cmdlet
+            if (this.urlParser.getHttpMethod().contains(HttpVerb[HttpVerb.GET], true)) {
+                this.supportedCommands.push({ cmd: CmdType.Get, isAction: false, isSetAction: false });
+            }
+            else if (this.urlParser.getHttpMethod().contains(HttpVerb[HttpVerb.POST], true) && this.urlParser.getOriginalURL().contains("list", true)) {
+                this.supportedCommands.push({ cmd: CmdType.Invoke, isAction: false, isSetAction: false });
+            }
+
+            // add SET related cmdlet
+            if (resourceActions.some(a => (a.toUpperCase() === ResourceActions[ResourceActions.PATCH] || a.toUpperCase() === ResourceActions[ResourceActions.PUT]))) {
+                if (resourceActions.includes(ResourceActions[ResourceActions.GET])) {
+                    this.supportedCommands.push({ cmd: CmdType.Set, isAction: false, isSetAction: true });
+                }
+                else {
+                    this.supportedCommands.push({ cmd: CmdType.New, isAction: false, isSetAction: true });
+                }
+            }
+
+            // add create related cmdlet
+            if (resourceActions.includes(ResourceActions[ResourceActions.CREATE])) {
+                if (this.urlParser.isResourceGroupURL()) {
+                    this.supportedCommands.push({ cmd: CmdType.NewResourceGroup, isAction: false, isSetAction: false });
+                }
+                else {
+                    this.supportedCommands.push({ cmd: CmdType.New, isAction: false, isSetAction: false });
+                }
+            }
+
+            // add actions
+            if (this.urlParser.getActions().length > 0) {
+                this.urlParser.getActions().forEach(action => {
+                    if (action.httpMethod.toUpperCase() === HttpVerb[HttpVerb.DELETE]) {
+                        this.supportedCommands.push({ cmd: CmdType.RemoveAction, isAction: true, isSetAction: false });
+                    }
+                    else if (action.httpMethod.toUpperCase() === HttpVerb[HttpVerb.POST]) {
+                        this.supportedCommands.push({ cmd: CmdType.InvokeAction, isAction: true, isSetAction: false });
+                    }
+                });
+            }
+        }
+
+        getSupportedCommands(): Array<RMCommandInfo> {
+            return this.supportedCommands;
+        }
+
+        private doGetActionName(url: string): string {
+            return url.substr(url.lastIndexOf("/") + 1, url.length - url.lastIndexOf("/") - 1);
+        }
+
+        getActionName(): string {
+            return this.doGetActionName(this.urlParser.getURL());
+        }
+
+        getActionParameters(actionIndex: number): IAction {
+            return this.urlParser.getActions()[actionIndex];
+        }
+
+        getActionNameFromAction(actionIndex: number): string {
+            return this.doGetActionName(this.getActionParameters(actionIndex).url);
+        }
+
+        getActionNameFromList(): string {
+            return this.doGetActionName(this.urlParser.getURL().replace("/list", ""));
+        }
+
+        getResourceName(): string {
+            return this.urlParser.getURL().substr(this.urlParser.getURL().lastIndexOf("/") + 1, this.urlParser.getURL().length - this.urlParser.getURL().lastIndexOf("/") - 2);
+        }
+
+        // Applicable only for Get-AzureRmResource
+        private supportsCollection(resourceName: string): boolean{
+
+            // -IsCollection will force Get-AzureRmResource to query RP instead of the cache. 
+            // But when ResourceName is available Get-AzureRmResource will always hit RP so skip -IsCollection flag.
+
+            // children are either an array or a string
+            // if array
+            //      Predefined list of options. Like Providers or (config, appsettings, etc)
+            // else if string
+            //      this means it's a Url that we need to go fetch and display.
+            return !!(!resourceName && (typeof this.urlParser.getResourceDefinitionChildren() === "string")) && this.urlParser.hasResourceProvider();
+        }
+
+        getParameters(): CmdletParameters {
+            let cmd = {} as CmdletParameters;
+            cmd.apiVersion = this.urlParser.getAPIVersion();
+            cmd.resourceIdentifier = this.urlParser.getResourceIdentifier();
+            cmd.isCollection = this.supportsCollection(cmd.resourceIdentifier.resourceName);
+            return cmd;
+        }
+    }
+}
+

--- a/ng/angularPolyfill.ts
+++ b/ng/angularPolyfill.ts
@@ -1,0 +1,11 @@
+﻿interface Element {
+    documentOffsetTop(): number;
+}
+
+if (!Element.prototype.documentOffsetTop) {
+    Element.prototype.documentOffsetTop = function () {
+        return this.offsetTop + (this.offsetParent ? this.offsetParent.documentOffsetTop() : 0);
+    };
+}
+
+

--- a/ng/manage.ts
+++ b/ng/manage.ts
@@ -1,4 +1,6 @@
-﻿//http://stackoverflow.com/a/22253161
+﻿module armExplorer
+{
+//http://stackoverflow.com/a/22253161
 angular.module('mp.resizer', []).directive('resizer', function ($document) {
 
     return function ($scope, $element, $attrs) {
@@ -58,593 +60,593 @@ angular.module('mp.resizer', []).directive('resizer', function ($document) {
 angular.module("armExplorer", ["ngRoute", "ngAnimate", "ngSanitize", "ui.bootstrap", "angularBootstrapNavTree", "rx", "mp.resizer", "ui.ace"])
     .controller("treeBodyController", ["$scope", "$routeParams", "$location", "$http", "$q", "$timeout", "rx", "$document", ($scope: ArmTreeScope, $routeParams: ng.route.IRouteParamsService, $location: ng.ILocationService, $http: ng.IHttpService, $q: ng.IQService, $timeout: ng.ITimeoutService, rx: any, $document: ng.IDocumentService) => {
 
-    $scope.treeControl = <ITreeControl>{};
-    $scope.createModel = {};
-    $scope.actionsModel = {};
-    $scope.resourcesDefinitionsTable = [];
-    $scope.resources = [];
-    $scope.readOnlyMode = true;
-    $scope.editMode = false;
-    $scope.activeTab = [false, false, false, false];
-    $scope.treeBranchDataOverrides = getTreeBranchDataOverrides();
+        $scope.treeControl = <ITreeControl>{};
+        $scope.createModel = {};
+        $scope.actionsModel = {};
+        $scope.resourcesDefinitionsTable = [];
+        $scope.resources = [];
+        $scope.readOnlyMode = true;
+        $scope.editMode = false;
+        $scope.activeTab = [false, false, false, false];
+        $scope.treeBranchDataOverrides = getTreeBranchDataOverrides();
 
-    $scope.aceConfig = {
-        mode: "json",
-        theme: "tomorrow",
-        onLoad: (_ace) => {
-            _ace.setOptions({
-                maxLines: Infinity,
-                fontSize: 15,
-                wrap: "free",
-                showPrintMargin: false
-            });
-            _ace.resize();
-        }
-    };
-
-    var responseEditor, requestEditor, createEditor, powershellEditor;
-    $timeout(() => {
-        responseEditor = ace.edit("response-json-editor");
-        requestEditor = ace.edit("request-json-editor");
-        createEditor = ace.edit("json-create-editor");
-        powershellEditor = ace.edit("powershell-editor");
-        [responseEditor, requestEditor, createEditor, powershellEditor].map((e) => {
-            e.setOptions({
-                maxLines: Infinity,
-                fontSize: 15,
-                wrap: "free",
-                showPrintMargin: false
-            });
-            e.setTheme("ace/theme/tomorrow");
-            e.getSession().setMode("ace/mode/json");
-            e.getSession().setNewLineMode("windows")
-            e.customSetValue = function (stringValue) {
-                this.setValue(stringValue);
-                this.session.selection.clearSelection();
-                this.moveCursorTo(0, 0);
-            };
-            e.setReadOnly = function (setBackground?: boolean) {
-                setBackground = typeof setBackground !== 'undefined' ? setBackground : true;
-                this.setOptions({
-                    readOnly: true,
-                    highlightActiveLine: false,
-                    highlightGutterLine: false
+        $scope.aceConfig = {
+            mode: "json",
+            theme: "tomorrow",
+            onLoad: (_ace) => {
+                _ace.setOptions({
+                    maxLines: Infinity,
+                    fontSize: 15,
+                    wrap: "free",
+                    showPrintMargin: false
                 });
-                this.renderer.$cursorLayer.element.style.opacity = 0;
-                this.renderer.setStyle("disabled", true);
-                if (setBackground) this.container.style.background = "#f5f5f5";
-                this.blur();
-            };
-            e.commands.removeCommand("find");
-            // Bind CTRL-S as PATCH or PUT
-            e.commands.addCommand({
-                name: 'saveItem',
-                bindKey: {
-                    win: 'Ctrl-S',
-                    mac: 'Command-S',
-                    sender: 'editor|cli'
-                },
-                exec: function () {
-                    let method = $scope.selectedResource.httpMethods.
-                        find(m => (m === 'PATCH' || m === 'PUT'));
-                    // Just in case the .find() breaks in unforseen ways
-                    if (typeof method !== 'undefined' && method !== null) {
-                        invokePutOrPatch(method, event);
-                    }
-                    else {
-                        console.error("$scope.selectedResource does not support PATCH or PUT. Ignoring CTRL-S/Command-S.");
-                    }
-                }
-            });
-        });
-        responseEditor.setReadOnly();
-        responseEditor.customSetValue(stringify({ message: "Select a node to start" }));
-        powershellEditor.setReadOnly(false);
-        powershellEditor.getSession().setMode("ace/mode/powershell");
-        powershellEditor.setTheme("ace/theme/tomorrow_night_blue");
-        powershellEditor.renderer.setShowGutter(false); 
-        powershellEditor.customSetValue("# PowerShell equivalent script");
+                _ace.resize();
+            }
+        };
 
-    });
-
-    $document.on('mouseup',() => {
+        var responseEditor, requestEditor, createEditor, powershellEditor;
         $timeout(() => {
-            [responseEditor, requestEditor, createEditor, powershellEditor].map(e => e.resize());
-        });
-    });
-
-    $scope.$createObservableFunction("selectResourceHandler")
-        .flatMapLatest((args: any[])  => {
-        var branch: ITreeBranch = args[0];
-        var event = args[1];
-        $scope.loading = true;
-        delete $scope.errorResponse;
-        if (branch.is_instruction) {
-            var parent = $scope.treeControl.get_parent_branch(branch);
-            $scope.treeControl.collapse_branch(parent);
-            $timeout(() => {
-                $scope.expandResourceHandler(parent, undefined, undefined, undefined, true /*dontFilterEmpty*/);
+            responseEditor = ace.edit("response-json-editor");
+            requestEditor = ace.edit("request-json-editor");
+            createEditor = ace.edit("json-create-editor");
+            powershellEditor = ace.edit("powershell-editor");
+            [responseEditor, requestEditor, createEditor, powershellEditor].map((e) => {
+                e.setOptions({
+                    maxLines: Infinity,
+                    fontSize: 15,
+                    wrap: "free",
+                    showPrintMargin: false
+                });
+                e.setTheme("ace/theme/tomorrow");
+                e.getSession().setMode("ace/mode/json");
+                e.getSession().setNewLineMode("windows")
+                e.customSetValue = function (stringValue) {
+                    this.setValue(stringValue);
+                    this.session.selection.clearSelection();
+                    this.moveCursorTo(0, 0);
+                };
+                e.setReadOnly = function (setBackground?: boolean) {
+                    setBackground = typeof setBackground !== 'undefined' ? setBackground : true;
+                    this.setOptions({
+                        readOnly: true,
+                        highlightActiveLine: false,
+                        highlightGutterLine: false
+                    });
+                    this.renderer.$cursorLayer.element.style.opacity = 0;
+                    this.renderer.setStyle("disabled", true);
+                    if (setBackground) this.container.style.background = "#f5f5f5";
+                    this.blur();
+                };
+                e.commands.removeCommand("find");
+                // Bind CTRL-S as PATCH or PUT
+                e.commands.addCommand({
+                    name: 'saveItem',
+                    bindKey: {
+                        win: 'Ctrl-S',
+                        mac: 'Command-S',
+                        sender: 'editor|cli'
+                    },
+                    exec: function () {
+                        let method = $scope.selectedResource.httpMethods.
+                            find(m => (m === 'PATCH' || m === 'PUT'));
+                        // Just in case the .find() breaks in unforseen ways
+                        if (typeof method !== 'undefined' && method !== null) {
+                            invokePutOrPatch(method, event);
+                        }
+                        else {
+                            console.error("$scope.selectedResource does not support PATCH or PUT. Ignoring CTRL-S/Command-S.");
+                        }
+                    }
+                });
             });
-        }
-        var resourceDefinition = branch.resourceDefinition;
-        if (!resourceDefinition) return rx.Observable.fromPromise($q.when({ branch: branch }));
-        $scope.apiVersion = resourceDefinition.apiVersion;
-        var getActions = resourceDefinition.actions.filter(a => (a === "GET" || a === "GETPOST"));
+            responseEditor.setReadOnly();
+            responseEditor.customSetValue(stringify({ message: "Select a node to start" }));
+            powershellEditor.setReadOnly(false);
+            powershellEditor.getSession().setMode("ace/mode/powershell");
+            powershellEditor.setTheme("ace/theme/tomorrow_night_blue");
+            powershellEditor.renderer.setShowGutter(false);
+            powershellEditor.customSetValue("# PowerShell equivalent script");
 
-        if (getActions.length === 1) {
-            var getAction = (getActions[0] === "GETPOST" ? "POST" : "GET");
-            var url = (getAction === "POST" ? branch.elementUrl + "/list" : branch.elementUrl);
-            var httpConfig = {
+        });
+
+        $document.on('mouseup', () => {
+            $timeout(() => {
+                [responseEditor, requestEditor, createEditor, powershellEditor].map(e => e.resize());
+            });
+        });
+
+        $scope.$createObservableFunction("selectResourceHandler")
+            .flatMapLatest((args: any[]) => {
+                var branch: ITreeBranch = args[0];
+                var event = args[1];
+                $scope.loading = true;
+                delete $scope.errorResponse;
+                if (branch.is_instruction) {
+                    var parent = $scope.treeControl.get_parent_branch(branch);
+                    $scope.treeControl.collapse_branch(parent);
+                    $timeout(() => {
+                        $scope.expandResourceHandler(parent, undefined, undefined, undefined, true /*dontFilterEmpty*/);
+                    });
+                }
+                var resourceDefinition = branch.resourceDefinition;
+                if (!resourceDefinition) return rx.Observable.fromPromise($q.when({ branch: branch }));
+                $scope.apiVersion = resourceDefinition.apiVersion;
+                var getActions = resourceDefinition.actions.filter(a => (a === "GET" || a === "GETPOST"));
+
+                if (getActions.length === 1) {
+                    var getAction = (getActions[0] === "GETPOST" ? "POST" : "GET");
+                    var url = (getAction === "POST" ? branch.elementUrl + "/list" : branch.elementUrl);
+                    var httpConfig = {
+                        method: "POST",
+                        url: "api/operations",
+                        data: {
+                            Url: url,
+                            HttpMethod: getAction,
+                            ApiVersion: resourceDefinition.apiVersion
+                        }
+                    };
+                    $scope.loading = true;
+                    return rx.Observable.fromPromise($http(httpConfig))
+                        //http://stackoverflow.com/a/30878646/3234163
+                        .map(data => { return { resourceDefinition: resourceDefinition, data: data.data, url: url, branch: branch, httpMethod: getAction }; })
+                        .catch(error => rx.Observable.of({ error: error }));
+                }
+                return rx.Observable.of({ branch: branch, resourceDefinition: resourceDefinition });
+            })
+            .subscribe((value: ISelectHandlerReturn) => {
+                if (value.error) {
+                    var error = value.error;
+                    setStateForErrorOnResourceClick();
+                    if (error.config && error.config.resourceDefinition) {
+                        $scope.putUrl = error.config.filledInUrl;
+                        responseEditor.customSetValue("");
+                        $scope.readOnlyResponse = "";
+                    }
+                    $scope.errorResponse = syntaxHighlight({
+                        data: error.data,
+                        status: error.status
+                    });
+                    $scope.selectedResource = {
+                        url: $scope.putUrl,
+                        httpMethod: "GET"
+                    };
+                    fixSelectedTabIfNeeded();
+                    return;
+                }
+                setStateForClickOnResource();
+                if (value.data === undefined) {
+                    if (value.resourceDefinition !== undefined && !isEmptyObjectorArray(value.resourceDefinition.requestBody)) {
+                        responseEditor.customSetValue(stringify(value.resourceDefinition.requestBody));
+                    } else {
+                        responseEditor.customSetValue(stringify({ message: "No GET Url" }));
+                        powershellEditor.customSetValue("");
+                    }
+                    fixSelectedTabIfNeeded();
+                    return;
+                }
+                var resourceDefinition: IResourceDefinition = value.resourceDefinition;
+                var url = value.url;
+                $scope.putUrl = url;
+                if (resourceDefinition.actions.some(a => (a === "PATCH" || a === "PUT"))) {
+                    var editable: any;
+                    if (resourceDefinition.requestBody && isEmptyObjectorArray(resourceDefinition.requestBody.properties)) {
+                        editable = value.data;
+                    } else {
+                        editable = jQuery.extend(true, {}, resourceDefinition.requestBody);
+                        var dataCopy = jQuery.extend(true, {}, value.data);
+                        mergeObject(dataCopy, editable);
+                    }
+                    requestEditor.customSetValue(stringify(sortByObject(editable, value.data)));
+                    if (url.endsWith("list")) {
+                        $scope.putUrl = url.substring(0, url.lastIndexOf("/"));
+                    }
+                } else {
+                    requestEditor.customSetValue("");
+                }
+
+                responseEditor.customSetValue(stringify(value.data));
+
+                if (resourceDefinition.actions.includes("CREATE")) {
+                    $scope.creatable = true;
+                    $scope.createMetaData = resourceDefinition.requestBody;
+                    createEditor.customSetValue(stringify(resourceDefinition.requestBody));
+                }
+
+                var actionsAndVerbs = resourceDefinition.actions.filter(a => (a === "DELETE")).map(a => {
+                    return {
+                        httpMethod: a,
+                        name: "Delete",
+                        url: url
+                    };
+                });
+                var children = resourceDefinition.children;
+                if (typeof children !== "string" && Array.isArray(children)) {
+                    Array.prototype.push.apply(actionsAndVerbs, children.filter(childString => {
+                        var d = $scope.resourcesDefinitionsTable.filter(r => (r.resourceName === childString) && ((r.url === resourceDefinition.url) || r.url === (resourceDefinition.url + "/" + childString)));
+                        return d.length === 1;
+                    }).map(childString => {
+                        var d = getResourceDefinitionByNameAndUrl(childString, resourceDefinition.url + "/" + childString);
+                        if (d.children === undefined && Array.isArray(d.actions) && d.actions.filter(actionName => actionName === "POST").length > 0) {
+                            return {
+                                httpMethod: "POST",
+                                name: d.resourceName,
+                                url: url + "/" + d.resourceName,
+                                requestBody: (d.requestBody ? stringify(d.requestBody) : undefined),
+                                query: d.query
+                            };
+                        }
+                    }).filter(r => r !== undefined));
+                }
+                var doc = (resourceDefinition.responseBodyDoc ? resourceDefinition.responseBodyDoc : resourceDefinition.requestBodyDoc);
+                var docArray = getDocumentationFlatArray(value.data, doc);
+
+                $scope.selectedResource = {
+                    // Some resources may contain # or whitespace in name,
+                    // let's selectively URL-encode (for safety)
+                    url: selectiveUrlencode(url),
+                    actionsAndVerbs: actionsAndVerbs,
+                    httpMethods: resourceDefinition.actions.filter(e => e !== "DELETE" && e !== "CREATE").map((e) => (e === "GETPOST" ? "POST" : e)).sort(),
+                    doc: docArray
+                };
+                $location.path(url.replace(/https:\/\/[^\/]*\//, ""));
+
+                powershellEditor.customSetValue(getPowerShellScriptsForResource(value, actionsAndVerbs));
+                fixSelectedTabIfNeeded();
+            });
+
+        $scope.handleClick = (method, event) => {
+            if (method === "PUT" || method === "PATCH") {
+                invokePutOrPatch(method, event);
+            } else {
+                refreshContent();
+            }
+        };
+
+        $scope.invokeAction = (action, event) => {
+            _invokeAction(action, event);
+        };
+
+        function invokePutOrPatch(method: string, event: Event) {
+            try {
+                setStateForInvokePut();
+                var userObject = JSON.parse(requestEditor.getValue());
+                cleanObject(userObject);
+                userHttp({
                     method: "POST",
                     url: "api/operations",
                     data: {
-                        Url: url,
-                        HttpMethod: getAction,
-                        ApiVersion: resourceDefinition.apiVersion
+                        Url: $scope.putUrl,
+                        HttpMethod: method,
+                        RequestBody: userObject,
+                        ApiVersion: $scope.apiVersion
                     }
-                };
-            $scope.loading = true;
-            return rx.Observable.fromPromise($http(httpConfig))
-                //http://stackoverflow.com/a/30878646/3234163
-                .map(data => { return { resourceDefinition: resourceDefinition, data: data.data, url: url, branch: branch, httpMethod: getAction }; })
-                .catch(error => rx.Observable.of({ error: error }));
-        }
-        return rx.Observable.of({ branch: branch, resourceDefinition: resourceDefinition });
-        })
-        .subscribe((value: ISelelctHandlerReturn) => {
-        if (value.error) {
-            var error = value.error;
-            setStateForErrorOnResourceClick();
-            if (error.config && error.config.resourceDefinition) {
-                $scope.putUrl = error.config.filledInUrl;
-                responseEditor.customSetValue("");
-                $scope.readOnlyResponse = "";
-            }
-            $scope.errorResponse = syntaxHighlight({
-                data: error.data,
-                status: error.status
-            });
-            $scope.selectedResource = {
-                url: $scope.putUrl,
-                httpMethod: "GET"
-            };
-            fixSelectedTabIfNeeded();
-            return;
-        }
-        setStateForClickOnResource();
-        if (value.data === undefined) {
-            if (value.resourceDefinition !== undefined && !isEmptyObjectorArray(value.resourceDefinition.requestBody)) {
-                responseEditor.customSetValue(stringify(value.resourceDefinition.requestBody));
-            } else {
-                responseEditor.customSetValue(stringify({ message: "No GET Url" }));
-                powershellEditor.customSetValue("");
-            }
-            fixSelectedTabIfNeeded();
-            return; 
-        }
-        var resourceDefinition: IResourceDefinition = value.resourceDefinition;
-        var url = value.url;
-        $scope.putUrl = url;
-        if (resourceDefinition.actions.some(a => (a === "PATCH" || a === "PUT"))) {
-            var editable: any;
-            if (resourceDefinition.requestBody && isEmptyObjectorArray(resourceDefinition.requestBody.properties)) {
-                editable = value.data;
-            } else {
-                editable = jQuery.extend(true, {}, resourceDefinition.requestBody);
-                var dataCopy = jQuery.extend(true, {}, value.data);
-                mergeObject(dataCopy, editable);
-            }
-            requestEditor.customSetValue(stringify(sortByObject(editable, value.data)));
-            if (url.endsWith("list")) {
-                $scope.putUrl = url.substring(0, url.lastIndexOf("/"));
-            }
-        } else {
-            requestEditor.customSetValue("");
-        }
-
-        responseEditor.customSetValue(stringify(value.data));
-
-        if (resourceDefinition.actions.includes("CREATE")) {
-            $scope.creatable = true;
-            $scope.createMetaData = resourceDefinition.requestBody;
-            createEditor.customSetValue(stringify(resourceDefinition.requestBody));
-        }
-
-        var actionsAndVerbs = resourceDefinition.actions.filter(a => (a === "DELETE")).map(a => {
-            return {
-                httpMethod: a,
-                name: "Delete",
-                url: url
-            };
-        });
-        var children = resourceDefinition.children;
-        if (typeof children !== "string" && Array.isArray(children)) {
-            Array.prototype.push.apply(actionsAndVerbs, children.filter(childString => {
-                var d = $scope.resourcesDefinitionsTable.filter(r => (r.resourceName === childString) && ((r.url === resourceDefinition.url) || r.url === (resourceDefinition.url + "/" + childString)));
-                return d.length === 1;
-            }).map(childString => {
-                var d = getResourceDefinitionByNameAndUrl(childString, resourceDefinition.url + "/" + childString);
-                if (d.children === undefined && Array.isArray(d.actions) && d.actions.filter(actionName => actionName === "POST").length > 0) {
-                    return {
-                        httpMethod: "POST",
-                        name: d.resourceName,
-                        url: url + "/" + d.resourceName,
-                        requestBody: (d.requestBody ? stringify(d.requestBody) : undefined),
-                        query: d.query
-                    };
-                }
-            }).filter(r => r !== undefined));
-        }
-        var doc = (resourceDefinition.responseBodyDoc ? resourceDefinition.responseBodyDoc : resourceDefinition.requestBodyDoc);
-        var docArray = getDocumentationFlatArray(value.data, doc);
-
-        $scope.selectedResource = {
-            // Some resources may contain # or whitespace in name,
-            // let's selectively URL-encode (for safety)
-            url: selectiveUrlencode(url),
-            actionsAndVerbs: actionsAndVerbs,
-            httpMethods: resourceDefinition.actions.filter(e => e !== "DELETE" && e !== "CREATE").map((e) => (e === "GETPOST" ? "POST" : e)).sort(),
-            doc: docArray
-        };
-        $location.path(url.replace(/https:\/\/[^\/]*\//, ""));
-
-        powershellEditor.customSetValue(getPowerShellFromResource(value, actionsAndVerbs));
-        fixSelectedTabIfNeeded();
-    });
-
-    $scope.handleClick = (method, event) => {
-        if (method === "PUT" || method === "PATCH") {
-            invokePutOrPatch(method, event);
-        } else {
-            refreshContent();
-        }
-    };
-
-    $scope.invokeAction = (action, event) => {
-        _invokeAction(action, event);
-    };
-
-    function invokePutOrPatch(method: string, event: Event) {
-        try {
-            setStateForInvokePut();
-            var userObject = JSON.parse(requestEditor.getValue());
-            cleanObject(userObject);
-            userHttp({
-                method: "POST",
-                url: "api/operations",
-                data: {
-                    Url: $scope.putUrl,
-                    HttpMethod: method,
-                    RequestBody: userObject,
-                    ApiVersion: $scope.apiVersion
-                }
-            },() => {
+                }, () => {
                     $scope.selectResourceHandler($scope.treeControl.get_selected_branch(), undefined);
                     fadeInAndFadeOutSuccess();
-                },(err) => {
+                }, (err) => {
                     $scope.putError = syntaxHighlight(err);
                     fadeInAndFadeOutError();
-                },() => {
+                }, () => {
                     $scope.invoking = false;
                     $scope.loading = false;
                 }, event);
-        } catch (e) {
-            $scope.putError = syntaxHighlight({ error: "Error parsing JSON" });
-            $scope.invoking = false;
-            $scope.loading = false;
-        }
-    };
-
-    $scope.expandResourceHandler = (branch: ITreeBranch, row: any, event: Event, dontExpandChildren: boolean, dontFilterEmpty: boolean) => {
-        var promise: ng.IPromise<any> | ng.IHttpPromise<any> = $q.when();
-        if (branch.is_leaf) return promise;
-
-        if (branch.expanded) {
-            // clear the children array on collapse
-            branch.children.length = 0;
-            $scope.treeControl.collapse_branch(branch);
-            return promise;
-        }
-
-        var resourceDefinition = branch.resourceDefinition;
-        if (!resourceDefinition) return promise;
-
-        // children are either an array or a string
-        // if array
-        //      Predefined list of options. Like Providers or (config, appsettings, etc)
-        // else if string
-        //      this means it's a Url that we need to ge fetch and display.
-
-        var children = resourceDefinition.children;
-        if (typeof children !== "string" && Array.isArray(children)) {
-            if (isItemOf(branch, "subscriptions")) {
-                // if we are expanding an element of subscriptions (a subscription),
-                // then we need to make a request to the server to get a list of available providers in its resourceGroups
-                // then we can continue with normal expanding of an item
-                var originalIcon = showExpandingTreeItemIcon(row, branch);
-                promise = $http({
-                    method: "GET",
-                    url: "api/operations/providers/" + branch.value
-                }).success((data: any[]) => {
-                    branch.providersFilter = data;
-                }).finally(() => {
-                    endExpandingTreeItem(branch, originalIcon);
-                });
+            } catch (e) {
+                $scope.putError = syntaxHighlight({ error: "Error parsing JSON" });
+                $scope.invoking = false;
+                $scope.loading = false;
             }
-            let childrenArray: string[] = children;
-            promise = promise.finally(() => {
-                var filtedList = false;
-                branch.children = childrenArray.filter((childName) => {
-                    var childDefinition = getResourceDefinitionByNameAndUrl(childName, resourceDefinition.url + "/" + childName);
-                    if (!childDefinition) return false;
-                    if (childDefinition.children === undefined &&
-                        Array.isArray(childDefinition.actions) &&
-                        childDefinition.actions.filter(actionName => actionName === "POST").length > 0) {
-                        return false;
-                    }
-                    if (!dontFilterEmpty) {
-                        var keepResult = keepChildrenBasedOnExistingResources(branch, childName);
-                        filtedList = filtedList ? filtedList : !keepResult;
-                        return keepResult;
-                    } else {
-                        return true;
-                    }
-                }).map(childName => {
-                    var childDefinition = getResourceDefinitionByNameAndUrl(childName, resourceDefinition.url + "/" + childName);
-                    return {
-                        label: childName,
-                        resourceDefinition: childDefinition,
-                        is_leaf: (childDefinition.children ? false : true),
-                        elementUrl: branch.elementUrl + "/" + childName,
-                        sortValue: childName,
-                        iconNameOverride: null
-                    };
-                });
+        };
 
-                var offset = 0;
-                if (!dontFilterEmpty && filtedList) {
-                    var parent = $scope.treeControl.get_parent_branch(branch);
-                    if (branch.label === "providers" || (parent && parent.currentResourceGroupProviders)) {
-                        branch.children.unshift({
-                            label: "Show all",
-                            is_instruction: true,
-                            resourceDefinition: resourceDefinition,
-                            sortValue: null,
-                            iconNameOverride: null
-                        });
-                        offset++;
-                    }
-                }
+        $scope.expandResourceHandler = (branch: ITreeBranch, row: any, event: Event, dontExpandChildren: boolean, dontFilterEmpty: boolean) => {
+            var promise: ng.IPromise<any> | ng.IHttpPromise<any> = $q.when();
+            if (branch.is_leaf) return promise;
 
-                $scope.treeControl.expand_branch(branch);
-                if ((branch.children.length - offset) === 1 && !dontExpandChildren) {
-                    $timeout(() => {
-                        $scope.expandResourceHandler($scope.treeControl.get_first_non_instruction_child(branch));
+            if (branch.expanded) {
+                // clear the children array on collapse
+                branch.children.length = 0;
+                $scope.treeControl.collapse_branch(branch);
+                return promise;
+            }
+
+            var resourceDefinition = branch.resourceDefinition;
+            if (!resourceDefinition) return promise;
+
+            // children are either an array or a string
+            // if array
+            //      Predefined list of options. Like Providers or (config, appsettings, etc)
+            // else if string
+            //      this means it's a Url that we need to ge fetch and display.
+
+            var children = resourceDefinition.children;
+            if (typeof children !== "string" && Array.isArray(children)) {
+                if (isItemOf(branch, "subscriptions")) {
+                    // if we are expanding an element of subscriptions (a subscription),
+                    // then we need to make a request to the server to get a list of available providers in its resourceGroups
+                    // then we can continue with normal expanding of an item
+                    var originalIcon = showExpandingTreeItemIcon(row, branch);
+                    promise = $http({
+                        method: "GET",
+                        url: "api/operations/providers/" + branch.value
+                    }).success((data: any[]) => {
+                        branch.providersFilter = data;
+                    }).finally(() => {
+                        endExpandingTreeItem(branch, originalIcon);
                     });
                 }
-            });
-        } else if (typeof children === "string") {
-            var getUrl = branch.elementUrl;
+                let childrenArray: string[] = children;
+                promise = promise.finally(() => {
+                    var filtedList = false;
+                    branch.children = childrenArray.filter((childName) => {
+                        var childDefinition = getResourceDefinitionByNameAndUrl(childName, resourceDefinition.url + "/" + childName);
+                        if (!childDefinition) return false;
+                        if (childDefinition.children === undefined &&
+                            Array.isArray(childDefinition.actions) &&
+                            childDefinition.actions.filter(actionName => actionName === "POST").length > 0) {
+                            return false;
+                        }
+                        if (!dontFilterEmpty) {
+                            var keepResult = keepChildrenBasedOnExistingResources(branch, childName);
+                            filtedList = filtedList ? filtedList : !keepResult;
+                            return keepResult;
+                        } else {
+                            return true;
+                        }
+                    }).map(childName => {
+                        var childDefinition = getResourceDefinitionByNameAndUrl(childName, resourceDefinition.url + "/" + childName);
+                        return {
+                            label: childName,
+                            resourceDefinition: childDefinition,
+                            is_leaf: (childDefinition.children ? false : true),
+                            elementUrl: branch.elementUrl + "/" + childName,
+                            sortValue: childName,
+                            iconNameOverride: null
+                        };
+                    });
 
-            var originalIcon = showExpandingTreeItemIcon(row, branch);
-            var httpConfig = (getUrl.endsWith("resourceGroups") || getUrl.endsWith("subscriptions") || getUrl.split("/").length === 3)
-                ? {
-                    method: "GET",
-                    url: "api" + getUrl.substring(getUrl.indexOf("/subscriptions"))
+                    var offset = 0;
+                    if (!dontFilterEmpty && filtedList) {
+                        var parent = $scope.treeControl.get_parent_branch(branch);
+                        if (branch.label === "providers" || (parent && parent.currentResourceGroupProviders)) {
+                            branch.children.unshift({
+                                label: "Show all",
+                                is_instruction: true,
+                                resourceDefinition: resourceDefinition,
+                                sortValue: null,
+                                iconNameOverride: null
+                            });
+                            offset++;
+                        }
+                    }
+
+                    $scope.treeControl.expand_branch(branch);
+                    if ((branch.children.length - offset) === 1 && !dontExpandChildren) {
+                        $timeout(() => {
+                            $scope.expandResourceHandler($scope.treeControl.get_first_non_instruction_child(branch));
+                        });
+                    }
+                });
+            } else if (typeof children === "string") {
+                var getUrl = branch.elementUrl;
+
+                var originalIcon = showExpandingTreeItemIcon(row, branch);
+                var httpConfig = (getUrl.endsWith("resourceGroups") || getUrl.endsWith("subscriptions") || getUrl.split("/").length === 3)
+                    ? {
+                        method: "GET",
+                        url: "api" + getUrl.substring(getUrl.indexOf("/subscriptions"))
+                    }
+                    : {
+                        method: "POST",
+                        url: "api/operations",
+                        data: {
+                            Url: getUrl,
+                            HttpMethod: "GET",
+                            ApiVersion: resourceDefinition.apiVersion
+                        }
+                    };
+                let childStr: string = children;
+                promise = $http(httpConfig).success((data: any) => {
+                    var childDefinition = getResourceDefinitionByNameAndUrl(childStr, resourceDefinition.url + "/" + resourceDefinition.children);
+
+                    // get the projection to use for the current node (i.e. functions to provide label, sort key, ...)
+                    var treeBranchProjection = getTreeBranchProjection(childDefinition);
+
+                    branch.children = (data.value ? data.value : data).map((d: any) => {
+                        var csmName = getCsmNameFromIdAndName(d.id, d.name);
+                        var label = treeBranchProjection.getLabel(d, csmName);
+                        return {
+                            label: label,
+                            resourceDefinition: childDefinition,
+                            value: (d.subscriptionId ? d.subscriptionId : csmName),
+                            is_leaf: (childDefinition.children ? false : true),
+                            elementUrl: branch.elementUrl + "/" + (d.subscriptionId ? d.subscriptionId : csmName),
+                            sortValue: treeBranchProjection.getSortKey(d, label),
+                            iconNameOverride: treeBranchProjection.getIconNameOverride(d),
+
+                        };
+                    }).sort((a: any, b: any) => {
+                        return a.sortValue.localeCompare(b.sortValue) * treeBranchProjection.sortOrder;
+                    });
+                }).finally(() => {
+                    endExpandingTreeItem(branch, originalIcon);
+                    $scope.treeControl.expand_branch(branch);
+                    if (branch.children && branch.children.length === 1 && !dontExpandChildren)
+                        $timeout(() => {
+                            $scope.expandResourceHandler($scope.treeControl.get_first_child(branch));
+                        });
+                });
+            }
+            return promise;
+        };
+
+        function keepChildrenBasedOnExistingResources(branch: ITreeBranch, childName: string): boolean {
+            var parent = $scope.treeControl.get_parent_branch(branch);
+            if (branch.label === "providers") {
+                // filter the providers by providersFilter
+                var providersFilter: any = getProvidersFilter(branch);
+                if (providersFilter) {
+                    var currentResourceGroup = (parent && isItemOf(parent, "resourceGroups") ? parent.label : undefined);
+                    if (currentResourceGroup) {
+                        var currentResourceGroupProviders: any = providersFilter[currentResourceGroup.toUpperCase()];
+                        if (currentResourceGroupProviders) {
+                            branch.currentResourceGroupProviders = currentResourceGroupProviders;
+                            return (currentResourceGroupProviders[childName.toUpperCase()] ? true : false);
+                        } else {
+                            return false;
+                        }
+                    }
                 }
-                : {
+            } else if (parent && parent.currentResourceGroupProviders) {
+                return parent.currentResourceGroupProviders[branch.label.toUpperCase()] &&
+                    parent.currentResourceGroupProviders[branch.label.toUpperCase()].some((c: string) => c.toUpperCase() === childName.toUpperCase());
+            }
+            return true;
+        }
+
+        $scope.tenantSelect = () => {
+            window.location.href = "api/tenants/" + $scope.selectedTenant.id;
+        };
+
+        $scope.resourceSearch = () => {
+            // try to trigger cache refresh
+            refreshResourceCache();
+
+            // first performence search from local cache (should cover most of the case)
+            // so that user will have instance result
+            var results: IResourceSearchSuggestion[] = [];
+            var keyword = $scope.resourceSearchModel.searchKeyword || "";
+            var suggestionSortFunc = (a: any, b: any): number => {
+                var result = a.type.compare(b.type, true /*ignore case*/);
+                if (result === 0) {
+                    return a.name.compare(b.name, true /*ignore case*/);
+                }
+
+                return result;
+            };
+
+            // remember last keyword
+            // when merge latest data into cache and if cache is for current keyword, will also update suggestion list
+            $scope.resourceSearchCache.data.currentKeyword = keyword;
+
+            for (var itemKey in $scope.resourceSearchCache.data) {
+                var item = $scope.resourceSearchCache.data[itemKey];
+                if (item && item.name && item.type
+                    && (item.name.toLowerCase().indexOf(keyword.toLowerCase()) > -1 || item.type.toLowerCase().indexOf(keyword.toLowerCase()) > -1)) {
+                    results.push(item);
+                }
+            }
+
+            results.sort(suggestionSortFunc);
+
+            $scope.resourceSearchModel.suggestions = results;
+            if ($scope.resourceSearchModel.suggestions.length > 0) {
+                $scope.resourceSearchModel.isSuggestListDisplay = true;
+            } else {
+                $scope.resourceSearchModel.isSuggestListDisplay = false;
+            }
+
+            // do not trigger search by keyword if input is empty
+            if ($scope.resourceSearchCache.data.currentKeyword) {
+                // request from CSM to get more data, and merge into local cache
+                $http({
+                    method: "GET",
+                    url: ("api/search?keyword=" + keyword)
+                }).success((response: any[]) => {
+                    // update local cache
+                    response.forEach((item) => {
+                        // if not in local cache, and user still searching with current keyword, append to suggestion list
+                        if (keyword === $scope.resourceSearchCache.data.currentKeyword && !$scope.resourceSearchCache.data[item.id]) {
+                            $scope.resourceSearchModel.suggestions.push(<IResourceSearchSuggestion>item);
+                        }
+
+                        $scope.resourceSearchCache.data[item.id] = item;
+                    });
+                });
+            }
+        };
+
+        $scope.$createObservableFunction("delayResourceSearch")
+            .flatMapLatest((event) => {
+
+                // set 300 millionseconds gap, since user might still typing, 
+                // we want to trigger search only when user stop typing
+                return $timeout(() => { return event; }, 300);
+            }).subscribe((event) => {
+                if (!event || event.keyCode !== 13 /* enter key will handle by form-submit */) {
+                    $scope.resourceSearch();
+                }
+            });
+
+        $scope.selectResourceSearch = (item) => {
+            var itemId = item.id;
+            var currentSelectedBranch = $scope.treeControl.get_selected_branch();
+            if (currentSelectedBranch) {
+                var commonAncestor = findCommonAncestor(item.id, $scope.treeControl.get_selected_branch().elementUrl);
+
+                while (currentSelectedBranch != null && !currentSelectedBranch.elementUrl.toLowerCase().endsWith(commonAncestor)) {
+                    currentSelectedBranch = $scope.treeControl.get_parent_branch(currentSelectedBranch);
+                }
+
+                if (currentSelectedBranch) {
+                    $scope.treeControl.select_branch(currentSelectedBranch);
+                    var subscriptionTokenIndex = currentSelectedBranch.elementUrl.toLowerCase().indexOf("/subscriptions");
+                    var currentSelectedBranchPath = currentSelectedBranch.elementUrl.substr(subscriptionTokenIndex);
+                    itemId = itemId.substr(currentSelectedBranchPath.length);
+                } else {
+                    // shouldn`t happen, but if it did happen, we fallback to collaps_all
+                    $scope.treeControl.collapse_all();
+                }
+            }
+
+            handlePath(itemId.substr(1));
+            $scope.resourceSearchModel.isSuggestListDisplay = false;
+        };
+
+        $scope.enterCreateMode = () => {
+            $scope.createMode = true;
+            createEditor.resize();
+            delete $scope.createModel.createdResourceName;
+        };
+
+        $scope.leaveCreateMode = () => {
+            $scope.createMode = false;
+            responseEditor.resize();
+            requestEditor.resize();
+        };
+
+        $scope.clearCreate = () => {
+            delete $scope.createModel.createdResourceName;
+            createEditor.customSetValue(stringify($scope.createMetaData));
+        };
+
+        $scope.invokeCreate = (event) => {
+            try {
+                var resourceName = $scope.createModel.createdResourceName;
+                if (!resourceName) {
+                    $scope.createError = syntaxHighlight({
+                        error: {
+                            message: "{Resource Name} can't be empty"
+                        }
+                    });
+                    $scope.invoking = false;
+                    $scope.loading = false;
+                    return;
+                }
+
+                delete $scope.createError;
+                var userObject = JSON.parse(createEditor.getValue());
+                cleanObject(userObject);
+                $scope.invoking = true;
+                var selectedBranch = $scope.treeControl.get_selected_branch();
+                userHttp({
                     method: "POST",
                     url: "api/operations",
                     data: {
-                        Url: getUrl,
-                        HttpMethod: "GET",
-                        ApiVersion: resourceDefinition.apiVersion
+                        Url: $scope.putUrl + "/" + resourceName,
+                        HttpMethod: "PUT",
+                        RequestBody: userObject,
+                        ApiVersion: $scope.apiVersion
                     }
-                };
-            let childStr: string = children;
-            promise = $http(httpConfig).success((data: any) => {
-                var childDefinition = getResourceDefinitionByNameAndUrl(childStr, resourceDefinition.url + "/" + resourceDefinition.children);
-                
-                // get the projection to use for the current node (i.e. functions to provide label, sort key, ...)
-                var treeBranchProjection = getTreeBranchProjection(childDefinition);
-
-                branch.children = (data.value ? data.value : data).map((d: any) => {
-                    var csmName = getCsmNameFromIdAndName(d.id, d.name);
-                    var label = treeBranchProjection.getLabel(d, csmName);
-                    return {
-                        label: label,
-                        resourceDefinition: childDefinition,
-                        value: (d.subscriptionId ? d.subscriptionId : csmName),
-                        is_leaf: (childDefinition.children ? false : true),
-                        elementUrl: branch.elementUrl + "/" + (d.subscriptionId ? d.subscriptionId : csmName),
-                        sortValue: treeBranchProjection.getSortKey(d, label),
-                        iconNameOverride: treeBranchProjection.getIconNameOverride(d),
-                        
-                    };
-                }).sort((a: any, b: any) => {
-                    return a.sortValue.localeCompare(b.sortValue) * treeBranchProjection.sortOrder;
-                });
-            }).finally(() => {
-                endExpandingTreeItem(branch, originalIcon);
-                $scope.treeControl.expand_branch(branch);
-                if (branch.children && branch.children.length === 1 && !dontExpandChildren)
-                    $timeout(() => {
-                        $scope.expandResourceHandler($scope.treeControl.get_first_child(branch));
-                    });
-            });
-        }
-        return promise;
-    };
-
-    function keepChildrenBasedOnExistingResources(branch: ITreeBranch, childName: string): boolean {
-        var parent = $scope.treeControl.get_parent_branch(branch);
-        if (branch.label === "providers") {
-            // filter the providers by providersFilter
-            var providersFilter: any = getProvidersFilter(branch);
-            if (providersFilter) {
-                var currentResourceGroup = (parent && isItemOf(parent, "resourceGroups") ? parent.label : undefined);
-                if (currentResourceGroup) {
-                    var currentResourceGroupProviders: any = providersFilter[currentResourceGroup.toUpperCase()];
-                    if (currentResourceGroupProviders) {
-                        branch.currentResourceGroupProviders = currentResourceGroupProviders;
-                        return (currentResourceGroupProviders[childName.toUpperCase()] ? true : false);
-                    } else {
-                        return false;
-                    }
-                }
-            }
-        } else if (parent && parent.currentResourceGroupProviders) {
-            return parent.currentResourceGroupProviders[branch.label.toUpperCase()] &&
-                parent.currentResourceGroupProviders[branch.label.toUpperCase()].some((c: string) => c.toUpperCase() === childName.toUpperCase());
-        }
-        return true;
-    }
-
-    $scope.tenantSelect = () => {
-        window.location.href = "api/tenants/" + $scope.selectedTenant.id;
-    };
-
-    $scope.resourceSearch = () => {
-        // try to trigger cache refresh
-        refreshResourceCache();
-
-        // first performence search from local cache (should cover most of the case)
-        // so that user will have instance result
-        var results: IResourceSearchSuggestion[] = [];
-        var keyword = $scope.resourceSearchModel.searchKeyword || "";
-        var suggestionSortFunc = (a: any, b: any): number => {
-            var result = a.type.compare(b.type, true /*ignore case*/);
-            if (result === 0) {
-                return a.name.compare(b.name, true /*ignore case*/);
-            }
-
-            return result;
-        };
-
-        // remember last keyword
-        // when merge latest data into cache and if cache is for current keyword, will also update suggestion list
-        $scope.resourceSearchCache.data.currentKeyword = keyword;
-
-        for (var itemKey in $scope.resourceSearchCache.data) {
-            var item = $scope.resourceSearchCache.data[itemKey];
-            if (item && item.name && item.type
-                && (item.name.toLowerCase().indexOf(keyword.toLowerCase()) > -1 || item.type.toLowerCase().indexOf(keyword.toLowerCase()) > -1)) {
-                results.push(item);
-            }
-        }
-
-        results.sort(suggestionSortFunc);
-
-        $scope.resourceSearchModel.suggestions = results;
-        if ($scope.resourceSearchModel.suggestions.length > 0) {
-            $scope.resourceSearchModel.isSuggestListDisplay = true;
-        } else {
-            $scope.resourceSearchModel.isSuggestListDisplay = false;
-        }
-
-        // do not trigger search by keyword if input is empty
-        if ($scope.resourceSearchCache.data.currentKeyword) {
-            // request from CSM to get more data, and merge into local cache
-            $http({
-                method: "GET",
-                url: ("api/search?keyword=" + keyword)
-            }).success((response: any[]) => {            
-                // update local cache
-                response.forEach((item) => {
-                    // if not in local cache, and user still searching with current keyword, append to suggestion list
-                    if (keyword === $scope.resourceSearchCache.data.currentKeyword && !$scope.resourceSearchCache.data[item.id]) {
-                        $scope.resourceSearchModel.suggestions.push(<IResourceSearchSuggestion>item);
-                    }
-
-                    $scope.resourceSearchCache.data[item.id] = item;
-                });
-            });
-        }
-    };
-
-    $scope.$createObservableFunction("delayResourceSearch")
-        .flatMapLatest((event) => {
-
-        // set 300 millionseconds gap, since user might still typing, 
-        // we want to trigger search only when user stop typing
-        return $timeout(() => { return event; }, 300);
-    }).subscribe((event) => {
-        if (!event || event.keyCode !== 13 /* enter key will handle by form-submit */) {
-            $scope.resourceSearch();
-        }
-    });
-
-    $scope.selectResourceSearch = (item) => {
-        var itemId = item.id;
-        var currentSelectedBranch = $scope.treeControl.get_selected_branch();
-        if (currentSelectedBranch) {
-            var commonAncestor = findCommonAncestor(item.id, $scope.treeControl.get_selected_branch().elementUrl);
-
-            while (currentSelectedBranch != null && !currentSelectedBranch.elementUrl.toLowerCase().endsWith(commonAncestor)) {
-                currentSelectedBranch = $scope.treeControl.get_parent_branch(currentSelectedBranch);
-            }
-
-            if (currentSelectedBranch) {
-                $scope.treeControl.select_branch(currentSelectedBranch);
-                var subscriptionTokenIndex = currentSelectedBranch.elementUrl.toLowerCase().indexOf("/subscriptions");
-                var currentSelectedBranchPath = currentSelectedBranch.elementUrl.substr(subscriptionTokenIndex);
-                itemId = itemId.substr(currentSelectedBranchPath.length);
-            } else {
-                // shouldn`t happen, but if it did happen, we fallback to collaps_all
-                $scope.treeControl.collapse_all();
-            }
-        }
-
-        handlePath(itemId.substr(1));
-        $scope.resourceSearchModel.isSuggestListDisplay = false;
-    };
-
-    $scope.enterCreateMode = () => {
-        $scope.createMode = true;
-        createEditor.resize();
-        delete $scope.createModel.createdResourceName;
-    };
-
-    $scope.leaveCreateMode = () => {
-        $scope.createMode = false;
-        responseEditor.resize();
-        requestEditor.resize();
-    };
-
-    $scope.clearCreate = () => {
-        delete $scope.createModel.createdResourceName;
-        createEditor.customSetValue(stringify($scope.createMetaData));
-    };
-
-    $scope.invokeCreate = (event) => {
-        try {
-            var resourceName = $scope.createModel.createdResourceName;
-            if (!resourceName) {
-                $scope.createError = syntaxHighlight({
-                    error: {
-                        message: "{Resource Name} can't be empty"
-                    }
-                });
-                $scope.invoking = false;
-                $scope.loading = false;
-                return;
-            }
-
-            delete $scope.createError;
-            var userObject = JSON.parse(createEditor.getValue());
-            cleanObject(userObject);
-            $scope.invoking = true;
-            var selectedBranch = $scope.treeControl.get_selected_branch();
-            userHttp({
-                method: "POST",
-                url: "api/operations",
-                data: {
-                    Url: $scope.putUrl + "/" + resourceName,
-                    HttpMethod: "PUT",
-                    RequestBody: userObject,
-                    ApiVersion: $scope.apiVersion
-                }
-            },() => {
+                }, () => {
                     $scope.treeControl.collapse_branch(selectedBranch);
                     if (selectedBranch.uid === $scope.treeControl.get_selected_branch().uid) {
                         $scope.selectResourceHandler($scope.treeControl.get_selected_branch(), undefined);
@@ -653,295 +655,295 @@ angular.module("armExplorer", ["ngRoute", "ngAnimate", "ngSanitize", "ui.bootstr
                     $timeout(() => {
                         $scope.expandResourceHandler(selectedBranch);
                     }, 50);
-                },(err) => {
+                }, (err) => {
                     $scope.createError = syntaxHighlight(err);
                     fadeInAndFadeOutError();
-                },() => {
+                }, () => {
                     $scope.invoking = false;
                     $scope.loading = false;
                 }, event);
-        } catch (e) {
-            $scope.createError = syntaxHighlight({ error: "Error parsing JSON" });
-            $scope.invoking = false;
-            $scope.loading = false;
-        }
-    };
-
-    function refreshContent() {
-        $scope.selectResourceHandler($scope.treeControl.get_selected_branch(), undefined);
-    };
-
-    $scope.enterDataTab = () => {
-        [responseEditor, requestEditor].map((e) => {
-            if (e) {
-                e.resize();
+            } catch (e) {
+                $scope.createError = syntaxHighlight({ error: "Error parsing JSON" });
+                $scope.invoking = false;
+                $scope.loading = false;
             }
-        });
-    };
+        };
 
-    $scope.hideDocs = () => {
+        function refreshContent() {
+            $scope.selectResourceHandler($scope.treeControl.get_selected_branch(), undefined);
+        };
 
-        var newWidth = $("#doc").outerWidth(true) + $("#content").outerWidth(true);
-        $("#content").css({ width: newWidth });
-        $("#doc").hide();
-        $("#doc-resizer").hide();
-        $("#show-doc-btn").show();
-    }
-
-    $scope.showDocs = () => {
-        $("#doc").show();
-        $("#doc-resizer").show();
-        var newWidth = $("#content").outerWidth(true) - $("#doc").outerWidth(true);
-        $("#content").css({ width: newWidth });
-        $("#show-doc-btn").hide();
-    }
-
-    $scope.hideConfirm = () => {
-        $(".confirm-box").fadeOut(300);
-        $('#dark-blocker').hide();
-    }
-
-    $scope.setReadOnlyMode = (readOnlyMode) => {
-        $scope.readOnlyMode = readOnlyMode;
-        $.cookie("readOnlyMode", readOnlyMode, { expires: 10 * 365, path: '/' });
-    }
-
-    $scope.toggleEditMode = () => {
-        $scope.editMode = !$scope.editMode;
-        $timeout(() => {
+        $scope.enterDataTab = () => {
             [responseEditor, requestEditor].map((e) => {
                 if (e) {
                     e.resize();
                 }
             });
-        });
-    }
-
-    $scope.showHttpVerb = (verb) => {
-        return ((verb === "GET" || verb === "POST") && !$scope.editMode) || ((verb === "PUT" || verb === "PATCH") && $scope.editMode);
-    };
-
-    $scope.logout = () => {
-        window.location.href = "/logout"
-    };
-
-    $scope.refresh = () => {
-        window.location.href = "/";
-    };
-
-    // https://www.reddit.com/r/web_design/comments/33kxgf/javascript_copying_to_clipboard_is_easier_than
-    $scope.copyResUrlToClipboard = (text: string) => {
-        // We can only use .select() on a textarea,
-        // so let's temporarily create one
-        var textField = document.createElement('textarea');
-        textField.innerText = text;
-        document.body.appendChild(textField);
-        textField.select();
-        if (document.execCommand('copy')) {
-            // Cycle resource URL color for visual feedback
-            $scope.resUrlColor = '#718c00'; // a soft green
-            $timeout(function () {
-                $scope.resUrlColor = '#000';
-            }, 350);
-        }
-        else {
-            console.error("document.execCommand('copy') returned false. " +
-                "Your browser may not support this feature or clipboard permissions don't allow it. " +
-                "See http://caniuse.com/#feat=document-execcommand.");
-        }
-        textField.remove();
-    }
-
-    // Get resourcesDefinitions
-    initResourcesDefinitions();
-
-    // Get tenants list
-    initTenants();
-
-    initSettings();
-
-    initUser();
-
-    initResourceSearch();
-
-    function initResourceSearch(): void {
-        $scope.resourceSearchModel = <IResourceSearch>{
-            isSuggestListDisplay: false,
-            suggestions: []
         };
 
-        refreshResourceCache();
-        // hide suggestion list when user click somewhere else
-        $("body").click(function (event) {
-            if (event && event.target
-                && event.target.getAttribute("id") !== "resource-search-input"
-                && !$.contains($("#resource-search-input")[0], event.target)
-                && event.target.getAttribute("id") !== "resource-search-list"
-                && !$.contains($("#resource-search-list")[0], event.target)) {
+        $scope.hideDocs = () => {
 
-                $scope.resourceSearchModel.isSuggestListDisplay = false;
+            var newWidth = $("#doc").outerWidth(true) + $("#content").outerWidth(true);
+            $("#content").css({ width: newWidth });
+            $("#doc").hide();
+            $("#doc-resizer").hide();
+            $("#show-doc-btn").show();
+        }
+
+        $scope.showDocs = () => {
+            $("#doc").show();
+            $("#doc-resizer").show();
+            var newWidth = $("#content").outerWidth(true) - $("#doc").outerWidth(true);
+            $("#content").css({ width: newWidth });
+            $("#show-doc-btn").hide();
+        }
+
+        $scope.hideConfirm = () => {
+            $(".confirm-box").fadeOut(300);
+            $('#dark-blocker').hide();
+        }
+
+        $scope.setReadOnlyMode = (readOnlyMode) => {
+            $scope.readOnlyMode = readOnlyMode;
+            $.cookie("readOnlyMode", readOnlyMode, { expires: 10 * 365, path: '/' });
+        }
+
+        $scope.toggleEditMode = () => {
+            $scope.editMode = !$scope.editMode;
+            $timeout(() => {
+                [responseEditor, requestEditor].map((e) => {
+                    if (e) {
+                        e.resize();
+                    }
+                });
+            });
+        }
+
+        $scope.showHttpVerb = (verb) => {
+            return ((verb === "GET" || verb === "POST") && !$scope.editMode) || ((verb === "PUT" || verb === "PATCH") && $scope.editMode);
+        };
+
+        $scope.logout = () => {
+            window.location.href = "/logout"
+        };
+
+        $scope.refresh = () => {
+            window.location.href = "/";
+        };
+
+        // https://www.reddit.com/r/web_design/comments/33kxgf/javascript_copying_to_clipboard_is_easier_than
+        $scope.copyResUrlToClipboard = (text: string) => {
+            // We can only use .select() on a textarea,
+            // so let's temporarily create one
+            var textField = document.createElement('textarea');
+            textField.innerText = text;
+            document.body.appendChild(textField);
+            textField.select();
+            if (document.execCommand('copy')) {
+                // Cycle resource URL color for visual feedback
+                $scope.resUrlColor = '#718c00'; // a soft green
+                $timeout(function () {
+                    $scope.resUrlColor = '#000';
+                }, 350);
             }
-        });
-    };
+            else {
+                console.error("document.execCommand('copy') returned false. " +
+                    "Your browser may not support this feature or clipboard permissions don't allow it. " +
+                    "See http://caniuse.com/#feat=document-execcommand.");
+            }
+            textField.remove();
+        }
 
-    var resourceCacheExpiration = 5 * 60 * 1000;    // 5 mintues
-    var isResourceCacheRefreshing: boolean = false;
-    function refreshResourceCache(): void {
-        if ((!$scope.resourceSearchCache || !$scope.resourceSearchCache.timestamp || Date.now() - $scope.resourceSearchCache.timestamp > resourceCacheExpiration)
-            && !isResourceCacheRefreshing) {
+        // Get resourcesDefinitions
+        initResourcesDefinitions();
 
-            isResourceCacheRefreshing = true;
+        // Get tenants list
+        initTenants();
 
+        initSettings();
+
+        initUser();
+
+        initResourceSearch();
+
+        function initResourceSearch(): void {
+            $scope.resourceSearchModel = <IResourceSearch>{
+                isSuggestListDisplay: false,
+                suggestions: []
+            };
+
+            refreshResourceCache();
+            // hide suggestion list when user click somewhere else
+            $("body").click(function (event) {
+                if (event && event.target
+                    && event.target.getAttribute("id") !== "resource-search-input"
+                    && !$.contains($("#resource-search-input")[0], event.target)
+                    && event.target.getAttribute("id") !== "resource-search-list"
+                    && !$.contains($("#resource-search-list")[0], event.target)) {
+
+                    $scope.resourceSearchModel.isSuggestListDisplay = false;
+                }
+            });
+        };
+
+        var resourceCacheExpiration = 5 * 60 * 1000;    // 5 mintues
+        var isResourceCacheRefreshing: boolean = false;
+        function refreshResourceCache(): void {
+            if ((!$scope.resourceSearchCache || !$scope.resourceSearchCache.timestamp || Date.now() - $scope.resourceSearchCache.timestamp > resourceCacheExpiration)
+                && !isResourceCacheRefreshing) {
+
+                isResourceCacheRefreshing = true;
+
+                $http({
+                    method: "GET",
+                    url: "api/search?keyword="
+                }).success((response: any[]) => {
+                    $scope.resourceSearchCache = <IResearchSearchCache>{
+                        data: {},
+                        timestamp: Date.now()
+                    };
+
+                    // turn array into hashmap, to allow easily update cache later
+                    response.forEach((item) => {
+                        $scope.resourceSearchCache.data[item.id] = item;
+                    });
+                }).finally(() => {
+                    isResourceCacheRefreshing = false;
+                });
+            }
+        };
+
+        function initUser() {
             $http({
                 method: "GET",
-                url: "api/search?keyword="
-            }).success((response: any[]) => {
-                $scope.resourceSearchCache = <IResearchSearchCache>{
-                    data: {},
-                    timestamp: Date.now()
+                url: "api/token"
+            }).success((data: any) => {
+                $scope.user = {
+                    name: (data.given_name && data.family_name ? data.given_name + " " + data.family_name : undefined) || data.name || data.email || data.unique_name || "User",
+                    imageUrl: "https://secure.gravatar.com/avatar/" + CryptoJS.MD5((data.email || data.unique_name || data.upn || data.name || "").toString()) + ".jpg?d=mm",
+                    email: "(" + (data.upn ? data.upn : data.email) + ")"
                 };
+            }).error(() => {
+                $scope.user = {
+                    name: "User",
+                    imageUrl: "https://secure.gravatar.com/avatar/.jpg?d=mm"
+                };
+            });
+        }
 
-                // turn array into hashmap, to allow easily update cache later
-                response.forEach((item) => {
-                    $scope.resourceSearchCache.data[item.id] = item;
+        function fixSelectedTabIfNeeded() {
+            var selectedIndex = $scope.activeTab.indexOf(true);
+            if ((!$scope.creatable && selectedIndex === 2) ||
+                (!($scope.selectedResource && $scope.selectedResource.actionsAndVerbs && $scope.selectedResource.actionsAndVerbs.length > 0) && selectedIndex === 1)) {
+                $timeout(() => {
+                    $scope.activeTab[0] = true;
                 });
-            }).finally(() => {
-                isResourceCacheRefreshing = false;
-            });
-        }
-    };
-
-    function initUser() {
-        $http({
-            method: "GET",
-            url: "api/token"
-        }).success((data: any) => {
-            $scope.user = {
-                name: (data.given_name && data.family_name ? data.given_name + " " + data.family_name : undefined) || data.name || data.email || data.unique_name || "User",
-                imageUrl: "https://secure.gravatar.com/avatar/" + CryptoJS.MD5((data.email || data.unique_name || data.upn || data.name || "").toString()) + ".jpg?d=mm",
-                email: "(" + (data.upn ? data.upn : data.email) + ")"
-            };
-        }).error(() => {
-            $scope.user = {
-                name: "User",
-                imageUrl: "https://secure.gravatar.com/avatar/.jpg?d=mm"
-            };
-        });
-    }
-
-    function fixSelectedTabIfNeeded() {
-        var selectedIndex = $scope.activeTab.indexOf(true);
-        if ((!$scope.creatable && selectedIndex === 2) ||
-            (!($scope.selectedResource && $scope.selectedResource.actionsAndVerbs && $scope.selectedResource.actionsAndVerbs.length > 0) && selectedIndex === 1)) {
-            $timeout(() => {
-                $scope.activeTab[0] = true;
-            });
-        }
-    }
-
-    function initSettings() {
-        if ($.cookie("readOnlyMode") !== undefined) {
-            $scope.setReadOnlyMode($.cookie("readOnlyMode") === "true");
-        }
-    }
-
-    function handlePath(path: string) {
-        if (path.length === 0) return;
-
-        var index = path.indexOf("/");
-        index = (index === -1 ? undefined : index);
-        var current = path.substring(0, index);
-        var rest = path.substring(index + 1);
-        var child: any;
-        var selectedBranch = $scope.treeControl.get_selected_branch();
-        var expandPromise: ng.IPromise<any> = $q.when();
-        var expandChild = () => {
-            if (!child) {
-                var top = document.getElementById("expand-icon-" + selectedBranch.uid).documentOffsetTop() - ((window.innerHeight - 50 /*nav bar height*/) / 2);
-                $("#sidebar").scrollTop(top);
-                return;
             }
-            $scope.treeControl.select_branch(child);
-            $timeout(() => {
-                child = $scope.treeControl.get_selected_branch();
-                if (child && $.isArray(child.children) && child.children.length > 0) {
-                    handlePath(rest);
-                } else {
-                    var promis = $scope.expandResourceHandler(child, undefined, undefined, true);
-                    promis.finally(() => { handlePath(rest); });
+        }
+
+        function initSettings() {
+            if ($.cookie("readOnlyMode") !== undefined) {
+                $scope.setReadOnlyMode($.cookie("readOnlyMode") === "true");
+            }
+        }
+
+        function handlePath(path: string) {
+            if (path.length === 0) return;
+
+            var index = path.indexOf("/");
+            index = (index === -1 ? undefined : index);
+            var current = path.substring(0, index);
+            var rest = path.substring(index + 1);
+            var child: any;
+            var selectedBranch = $scope.treeControl.get_selected_branch();
+            var expandPromise: ng.IPromise<any> = $q.when();
+            var expandChild = () => {
+                if (!child) {
+                    var top = document.getElementById("expand-icon-" + selectedBranch.uid).documentOffsetTop() - ((window.innerHeight - 50 /*nav bar height*/) / 2);
+                    $("#sidebar").scrollTop(top);
+                    return;
                 }
-            });
-        };
+                $scope.treeControl.select_branch(child);
+                $timeout(() => {
+                    child = $scope.treeControl.get_selected_branch();
+                    if (child && $.isArray(child.children) && child.children.length > 0) {
+                        handlePath(rest);
+                    } else {
+                        var promis = $scope.expandResourceHandler(child, undefined, undefined, true);
+                        promis.finally(() => { handlePath(rest); });
+                    }
+                });
+            };
 
 
-        if (!selectedBranch) {
-            var matches = $scope.treeControl.get_roots().filter(e => e.label.toLocaleUpperCase() === current.toLocaleUpperCase());
-            child = (matches.length > 0 ? matches[0] : undefined);
-            expandChild();
-        } else {
-            if (!selectedBranch.expanded) {
-                expandPromise = $scope.expandResourceHandler(selectedBranch, undefined, undefined, true);
-            }
-
-            expandPromise.then(() => {
-                var matches = $scope.treeControl.get_children(selectedBranch).filter(e => current.toLocaleUpperCase() === (e.value ? e.value.toLocaleUpperCase() : e.label.toLocaleUpperCase()));
+            if (!selectedBranch) {
+                var matches = $scope.treeControl.get_roots().filter(e => e.label.toLocaleUpperCase() === current.toLocaleUpperCase());
                 child = (matches.length > 0 ? matches[0] : undefined);
                 expandChild();
-            });
-        }
-    }
-
-    function setStateForClickOnResource() {
-        delete $scope.putError;
-        delete $scope.selectedResource;
-        $scope.invoking = false;
-        $scope.loading = false;
-        $scope.creatable = false;
-        $scope.editMode = false;
-    }
-
-    function setStateForErrorOnResourceClick() {
-        $scope.invoking = false;
-        $scope.loading = false;
-        $scope.editMode = false;
-    }
-
-    function setStateForInvokeAction() {
-        $scope.loading = true;
-        delete $scope.actionResponse;
-    }
-
-    function setStateForInvokePut() {
-        delete $scope.putError;
-        $scope.invoking = true;
-    }
-
-    function _invokeAction(action: IAction, event: Event, confirmed?: boolean) {
-        try {
-            setStateForInvokeAction();
-            var currentBranch = $scope.treeControl.get_selected_branch();
-            var parent = $scope.treeControl.get_parent_branch(currentBranch);
-            var body: any, queryString: string;
-            if (action.requestBody) {
-                var s = ace.edit(action.name + "-editor");
-                body = JSON.parse(s.getValue());
-            }
-            if (action.query) {
-                queryString = action.query.reduce((previous, current) => {
-                    return previous + (($scope.actionsModel[current] && $scope.actionsModel[current].trim() != "") ? "&" + current + "=" + $scope.actionsModel[current].trim() : "")
-                }, "");
-            }
-            userHttp({
-                method: "POST",
-                url: "api/operations",
-                data: {
-                    Url: action.url,
-                    RequestBody: body,
-                    HttpMethod: action.httpMethod,
-                    ApiVersion: $scope.apiVersion,
-                    QueryString: queryString
+            } else {
+                if (!selectedBranch.expanded) {
+                    expandPromise = $scope.expandResourceHandler(selectedBranch, undefined, undefined, true);
                 }
-            },(data, status) => {
+
+                expandPromise.then(() => {
+                    var matches = $scope.treeControl.get_children(selectedBranch).filter(e => current.toLocaleUpperCase() === (e.value ? e.value.toLocaleUpperCase() : e.label.toLocaleUpperCase()));
+                    child = (matches.length > 0 ? matches[0] : undefined);
+                    expandChild();
+                });
+            }
+        }
+
+        function setStateForClickOnResource() {
+            delete $scope.putError;
+            delete $scope.selectedResource;
+            $scope.invoking = false;
+            $scope.loading = false;
+            $scope.creatable = false;
+            $scope.editMode = false;
+        }
+
+        function setStateForErrorOnResourceClick() {
+            $scope.invoking = false;
+            $scope.loading = false;
+            $scope.editMode = false;
+        }
+
+        function setStateForInvokeAction() {
+            $scope.loading = true;
+            delete $scope.actionResponse;
+        }
+
+        function setStateForInvokePut() {
+            delete $scope.putError;
+            $scope.invoking = true;
+        }
+
+        function _invokeAction(action: IAction, event: Event, confirmed?: boolean) {
+            try {
+                setStateForInvokeAction();
+                var currentBranch = $scope.treeControl.get_selected_branch();
+                var parent = $scope.treeControl.get_parent_branch(currentBranch);
+                var body: any, queryString: string;
+                if (action.requestBody) {
+                    var s = ace.edit(action.name + "-editor");
+                    body = JSON.parse(s.getValue());
+                }
+                if (action.query) {
+                    queryString = action.query.reduce((previous, current) => {
+                        return previous + (($scope.actionsModel[current] && $scope.actionsModel[current].trim() != "") ? "&" + current + "=" + $scope.actionsModel[current].trim() : "")
+                    }, "");
+                }
+                userHttp({
+                    method: "POST",
+                    url: "api/operations",
+                    data: {
+                        Url: action.url,
+                        RequestBody: body,
+                        HttpMethod: action.httpMethod,
+                        ApiVersion: $scope.apiVersion,
+                        QueryString: queryString
+                    }
+                }, (data, status) => {
                     if (data) $scope.actionResponse = syntaxHighlight(data);
                     // async DELETE returns 202. That might fail later. So don't remove from the tree
                     if (action.httpMethod === "DELETE" && status === 200 /* OK */) {
@@ -954,794 +956,670 @@ angular.module("armExplorer", ["ngRoute", "ngAnimate", "ngSanitize", "ui.bootstr
                         $scope.selectResourceHandler($scope.treeControl.get_selected_branch(), undefined);
                     }
                     fadeInAndFadeOutSuccess();
-                },(err) => {
+                }, (err) => {
                     $scope.actionResponse = syntaxHighlight(err);
                     fadeInAndFadeOutError();
-                },() => { $scope.loading = false; }, event, confirmed);
-        } catch (e) {
-            $scope.actionResponse = syntaxHighlight({ error: "Error parsing JSON" });
-            $scope.loading = false;
+                }, () => { $scope.loading = false; }, event, confirmed);
+            } catch (e) {
+                $scope.actionResponse = syntaxHighlight({ error: "Error parsing JSON" });
+                $scope.loading = false;
+            }
         }
-    }
 
-    function fadeInAndFadeOutSuccess() {
-        setTimeout(() => {
-            $("#success-marker").fadeIn(1500);
+        function fadeInAndFadeOutSuccess() {
             setTimeout(() => {
-                $("#success-marker").fadeOut(1500);
-            }, 1200);
-        }, 500);
-    }
-
-    function fadeInAndFadeOutError() {
-        setTimeout(() => {
-            $("#failure-marker").fadeIn(1500);
-            setTimeout(() => {
-                $("#failure-marker").fadeOut(1500);
-            }, 1200);
-        }, 500);
-    }
-
-    function getCsmNameFromIdAndName(id: string, name: string) {
-        var splited = (id && id !== null ? decodeURIComponent(id) : name).split("/");
-        return splited[splited.length - 1];
-    }
-
-    function scrollToTop(delay: number) {
-        $timeout(() => {
-            $("html, body").scrollTop(0);
-        }, delay);
-    }
-
-    function getResourceDefinitionByNameAndUrl(name: string, url: string) {
-        var resourceDefinitions = $scope.resourcesDefinitionsTable.filter(r => (r.resourceName === name) && ((r.url.toLowerCase() === url.toLowerCase()) || r.url.toLowerCase() === (url.toLowerCase() + "/" + name.toLowerCase())));
-        if (resourceDefinitions.length > 1) {
-            console.log("ASSERT! duplicate ids in resourceDefinitionsTable");
-            console.log(resourceDefinitions);
+                $("#success-marker").fadeIn(1500);
+                setTimeout(() => {
+                    $("#success-marker").fadeOut(1500);
+                }, 1200);
+            }, 500);
         }
-        return resourceDefinitions[0];
-    }
 
-    function initTenants() {
-        $http({
-            method: "GET",
-            url: "api/tenants"
-        }).success((tenants: any[]) => {
-            $scope.tenants = tenants.map(tenant => {
-                return {
-                    name: tenant.DisplayName + " (" + tenant.DomainName + ")",
-                    id: tenant.TenantId,
-                    current: tenant.Current
-                };
-            });
-            $scope.selectedTenant = $scope.tenants[$scope.tenants.indexOfDelegate(tenant => tenant.current)];
-        });
-    }
+        function fadeInAndFadeOutError() {
+            setTimeout(() => {
+                $("#failure-marker").fadeIn(1500);
+                setTimeout(() => {
+                    $("#failure-marker").fadeOut(1500);
+                }, 1200);
+            }, 500);
+        }
 
-    function initResourcesDefinitions() {
-        $http({
-            method: "GET",
-            url: "api/operations"
-        }).success((operations: any[]) => {
-            operations.sort((a, b) => {
-                return a.Url.localeCompare(b.Url);
-            });
-            operations.map((operation) => {
-                //TODO: remove this
-                operation = fixOperationUrl(operation);
+        function getCsmNameFromIdAndName(id: string, name: string) {
+            var splited = (id && id !== null ? decodeURIComponent(id) : name).split("/");
+            return splited[splited.length - 1];
+        }
 
-                buildResourcesDefinitionsTable(operation);
+        function scrollToTop(delay: number) {
+            $timeout(() => {
+                $("html, body").scrollTop(0);
+            }, delay);
+        }
 
-                $scope.resourcesDefinitionsTable.map((r) => {
-                    var children = r.children;
-                    if (typeof children !== "string" && Array.isArray(children)) {
-                        children.sort();
-                    }
+        function getResourceDefinitionByNameAndUrl(name: string, url: string) {
+            var resourceDefinitions = $scope.resourcesDefinitionsTable.filter(r => (r.resourceName === name) && ((r.url.toLowerCase() === url.toLowerCase()) || r.url.toLowerCase() === (url.toLowerCase() + "/" + name.toLowerCase())));
+            if (resourceDefinitions.length > 1) {
+                console.log("ASSERT! duplicate ids in resourceDefinitionsTable");
+                console.log(resourceDefinitions);
+            }
+            return resourceDefinitions[0];
+        }
+
+        function initTenants() {
+            $http({
+                method: "GET",
+                url: "api/tenants"
+            }).success((tenants: any[]) => {
+                $scope.tenants = tenants.map(tenant => {
+                    return {
+                        name: tenant.DisplayName + " (" + tenant.DomainName + ")",
+                        id: tenant.TenantId,
+                        current: tenant.Current
+                    };
                 });
+                $scope.selectedTenant = $scope.tenants[$scope.tenants.indexOfDelegate(tenant => tenant.current)];
             });
-
-            // Initializes the root nodes for the tree
-            $scope.resources = getRootTreeNodes();
-
-        }).finally(() => { $timeout(() => { handlePath($location.path().substring(1)) }); });
-    }
-
-    function getRootTreeNodes() {
-
-        return $scope.resourcesDefinitionsTable.filter((rd) => { return rd.url.split("/").length === 4; })
-            .getUnique((rd) => { return rd.url.split("/")[3]; }).map((urd) => {
-            return {
-                label: urd.url.split("/")[3],
-                resourceDefinition: urd,
-                data: <any>undefined,
-                resource_icon: "fa fa-cube fa-fw",
-                children: <string[]>[],
-                elementUrl: urd.url
-            };
-        });
-    }
-
-    function fixOperationUrl(operation: IMetadataObject) {
-        if (operation.Url.indexOf("SourceControls/{name}") !== -1) {
-            operation.Url = operation.Url.replace("SourceControls/{name}", "SourceControls/{sourceControlName}");
-        }
-        if (operation.Url.indexOf("serverFarms/{name}") !== -1) {
-            operation.Url = operation.Url.replace("serverFarms/{name}", "serverFarms/{webHostingPlanName}");
-        }
-        if (operation.Url.indexOf("resourcegroups") !== -1) {
-            operation.Url = operation.Url.replace("resourcegroups", "resourceGroups");
-        }
-        if (operation.Url.endsWith("/")) {
-            operation.Url = operation.Url.substring(0, operation.Url.length - 1);
-        }
-        return operation;
-    }
-
-    function buildResourcesDefinitionsTable(operation: IMetadataObject, url?: string) {
-        url = (operation ? operation.Url : url);
-        url = url.replace(/{.*?}/g, "{name}");
-        var segments = url.split("/").filter(a => a.length !== 0);
-        var resourceName = segments.pop();
-        var addedElement: IResourceDefinition;
-
-        if (resourceName === "list" && operation && operation.HttpMethod === "POST") {
-            // handle resources that has a "secure GET"
-            setParent(url, "GETPOST", operation.RequestBody, operation.RequestBodyDoc, operation.ApiVersion);
-            return;
-        } else if (operation && (operation.MethodName.startsWith("Create") || operation.MethodName.startsWith("BeginCreate") || operation.MethodName.startsWith("Put")) && operation.HttpMethod === "PUT") {
-            // handle resources that has a CreateOrUpdate
-            setParent(url, "CREATE", operation.RequestBody, operation.RequestBodyDoc);
-            if (operation.MethodName.indexOf("Updat") === -1) {
-                return;
-            }
         }
 
-        //set the element itself
-        var elements = $scope.resourcesDefinitionsTable.filter(r => r.url.toLowerCase() === url.toLowerCase());
-        if (elements.length === 1) {
-            //it's there, update it's actions
-            if (operation) {
-                elements[0].requestBody = (elements[0].requestBody ? elements[0].requestBody : operation.RequestBody);
-                elements[0].apiVersion = operation.ApiVersion;
-                if (elements[0].actions.filter(c => c === operation.HttpMethod).length === 0) {
-                    elements[0].actions.push(operation.HttpMethod);
-                }
-                if (operation.HttpMethod === "GET") {
-                    elements[0].responseBodyDoc = operation.ResponseBodyDoc
-                } else if (operation.HttpMethod === "PUT") {
-                    elements[0].requestBodyDoc = operation.RequestBodyDoc;
-                }
-            }
-        } else {
-            addedElement = {
-                resourceName: resourceName,
-                children: undefined,
-                actions: (operation ? [operation.HttpMethod] : []),
-                url: url,
-                requestBody: operation ? operation.RequestBody : {},
-                requestBodyDoc: operation ? operation.RequestBodyDoc : {},
-                responseBodyDoc: operation ? operation.ResponseBodyDoc : {},
-                query: operation ? operation.Query : [],
-                apiVersion: operation && operation.ApiVersion ? operation.ApiVersion : undefined
-            };
-            $scope.resourcesDefinitionsTable.push(addedElement);
-        }
+        function initResourcesDefinitions() {
+            $http({
+                method: "GET",
+                url: "api/operations"
+            }).success((operations: any[]) => {
+                operations.sort((a, b) => {
+                    return a.Url.localeCompare(b.Url);
+                });
+                operations.map((operation) => {
+                    //TODO: remove this
+                    operation = fixOperationUrl(operation);
 
-        // set the parent recursively
-        setParent(url);
-        return addedElement;
-    };
+                    buildResourcesDefinitionsTable(operation);
 
-    function setParent(url: string, action?: string, requestBody?: any, requestBodyDoc?: any, apiVersion?: string) {
-        var segments = url.split("/").filter(a => a.length !== 0);
-        var resourceName = segments.pop();
-        var parentName = url.substring(0, url.lastIndexOf("/"));
-        if (parentName === undefined || parentName === "" || resourceName === undefined) return;
-        var parents = $scope.resourcesDefinitionsTable.filter(rd => rd.url.toLowerCase() === parentName.toLowerCase());
-        var parent: IResourceDefinition;
-        if (parents.length === 1) {
-            parent = parents[0];
-            if (resourceName.match(/\{.*\}/g)) {
-                // this means the parent.children should either be an undefined, or a string.
-                // if it's anything else assert! because that means we have a mistake in our assumptions
-                if (parent.children === undefined || typeof parent.children === "string") {
-                    parent.children = resourceName;
-                } else {
-                    console.log("ASSERT1, typeof parent.children: " + typeof parent.children)
-                }
-            } else if (resourceName !== "list") {
-                // this means that the resource is a pre-defined one. the parent.children should be undefined or array
-                // if it's anything else assert! because that means we have a mistake in out assumptions
-                if (parent.children === undefined) {
-                    parent.children = [resourceName];
-                } else if (Array.isArray(parent.children)) {
-                    if ((<string[]>parent.children).filter(c => c === resourceName).length === 0) {
-                        (<string[]>parent.children).push(resourceName);
-                    }
-                } else {
-                    parent.children = [resourceName];
-                    console.log("ASSERT2, typeof parent.children: " + typeof parent.children)
-                }
-            }
-        } else {
-            //this means the parent is not in the array. Add it
-            parent = buildResourcesDefinitionsTable(undefined, url.substring(0, url.lastIndexOf("/")));
-            setParent(url);
-        }
-
-        if (action && parent && parent.actions.filter(c => c === action).length === 0) {
-            parent.actions.push(action);
-        }
-
-        if (requestBody && parent && !parent.requestBody) {
-            parent.requestBody = requestBody;
-        }
-
-        if (requestBodyDoc && parent && !parent.requestBodyDoc) {
-            parent.requestBodyDoc = requestBodyDoc;
-        }
-
-        if (apiVersion && parent && !parent.apiVersion) {
-            parent.apiVersion = apiVersion;
-        }
-    }
-
-    function fixWidths(event: Event) {
-        if (!event) return;
-        var anchor = $(event.currentTarget);
-        var span = $(event.currentTarget).find("span");
-        var width = span.width() + parseInt(span.css("left"), 10) + 37;
-        anchor.width((width < 280 ? 280 : width) - 20);
-    }
-
-    function syntaxHighlight(json: any) {
-        if (typeof json === "string") return escapeHtmlEntities(json);
-        var str = stringify(json);
-        str = escapeHtmlEntities(str);
-        return str.replace(/("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?)/g,(match) => {
-            var cls = 'number';
-            if (/^"/.test(match)) {
-                if (/:$/.test(match)) {
-                    cls = 'key';
-                } else {
-                    cls = 'string';
-                }
-            } else if (/true|false/.test(match)) {
-                cls = 'boolean';
-            } else if (/null/.test(match)) {
-                cls = 'null';
-            }
-            if (cls === 'string' && ((match.slice(0, "\"http://".length) == "\"http://") || (match.slice(0, "\"https://".length) == "\"https://"))) {
-                match = match.replace("/api/", "/");
-                return '<span><a class="json-link" target="_blank" href=' + match + '>' + match + '</a></span>';
-            } else {
-                return '<span class="' + cls + '">' + match + '</span>';
-            }
-        });
-    }
-
-    function escapeHtmlEntities(str: string) {
-        return $('<div/>').text(str).html();
-    }
-
-    function selectiveUrlencode(url: string) {
-        return url.replace(/\#/g, '%23').replace(/\s/g, '%20');
-    }
-
-    function getRerouceGroupNameFromWebSpaceName(webSpaceName: string) {
-        webSpaceName = webSpaceName.toLowerCase();
-        if (!webSpaceName.endsWith("webspace")) {
-            return undefined;
-        }
-
-        // strip ending webspace
-        var ws = webSpaceName.substring(0, webSpaceName.length - 8);
-        var index = ws.lastIndexOf('-');
-        if (index < 0) {
-            return "Default-Web-" + ws;
-        }
-        else {
-            return ws.substring(0, index);
-        }
-    }
-
-    function isEmptyObjectorArray(obj: any) {
-        if (typeof obj === "number" || typeof obj === "boolean") return false;
-        if ($.isEmptyObject(obj)) return true;
-        if (obj === null || obj === "" || obj.length === 0) return true;
-        return false;
-    }
-
-    function cleanObject(obj: any) {
-        var hadProperties = (obj.properties !== undefined);
-        recursiveCleanObject(obj);
-        if (hadProperties && !obj.properties) {
-            obj.properties = {};
-        }
-    }
-
-    function recursiveCleanObject(obj: any) {
-        for (var property in obj) {
-            if (obj.hasOwnProperty(property)) {
-                if (typeof obj[property] === "string" && (/^\(.*\)$/.test(obj[property]))) {
-                    delete obj[property];
-                } else if (Array.isArray(obj[property])) {
-                    var hadElements = obj[property].length > 0;
-                    obj[property] = obj[property].filter((element: any) => {
-                        if (typeof element === "string" && (/^\(.*\)$/.test(element))) {
-                            return false
-                        } else if (typeof element === "object" && !$.isEmptyObject(element)) {
-                            recursiveCleanObject(element);
-                        } else if (typeof element === "object" && $.isEmptyObject(element)) {
-                            return false;
+                    $scope.resourcesDefinitionsTable.map((r) => {
+                        var children = r.children;
+                        if (typeof children !== "string" && Array.isArray(children)) {
+                            children.sort();
                         }
-                        if ($.isPlainObject(element) && $.isEmptyObject(element)) return false;
-                        return true;
                     });
-                    if (hadElements && obj[property].length === 0) delete obj[property];
-                } else if (typeof obj[property] === "object" && !$.isEmptyObject(obj[property])) {
-                    recursiveCleanObject(obj[property]);
-                    if ($.isEmptyObject(obj[property])) delete obj[property];
-                } else if (typeof obj[property] === "object" && $.isEmptyObject(obj[property])) {
-                    delete obj[property];
-                }
+                });
+
+                // Initializes the root nodes for the tree
+                $scope.resources = getRootTreeNodes();
+
+            }).finally(() => { $timeout(() => { handlePath($location.path().substring(1)) }); });
+        }
+
+        function getRootTreeNodes() {
+
+            return $scope.resourcesDefinitionsTable.filter((rd) => { return rd.url.split("/").length === 4; })
+                .getUnique((rd) => { return rd.url.split("/")[3]; }).map((urd) => {
+                    return {
+                        label: urd.url.split("/")[3],
+                        resourceDefinition: urd,
+                        data: <any>undefined,
+                        resource_icon: "fa fa-cube fa-fw",
+                        children: <string[]>[],
+                        elementUrl: urd.url
+                    };
+                });
+        }
+
+        function fixOperationUrl(operation: IMetadataObject) {
+            if (operation.Url.indexOf("SourceControls/{name}") !== -1) {
+                operation.Url = operation.Url.replace("SourceControls/{name}", "SourceControls/{sourceControlName}");
             }
-        }
-    }
-
-    function sortByObject(toBeSorted: any, toSortBy: any): any {
-        if (toBeSorted === toSortBy) return toBeSorted;
-        var sorted: any = {};
-        for (var key in toSortBy) {
-            if (toSortBy.hasOwnProperty(key)) {
-                var obj: any;
-                if (typeof toSortBy[key] === "object" && !Array.isArray(toSortBy[key]) && toSortBy[key] != null) {
-                    obj = sortByObject(toBeSorted[key], toSortBy[key]);
-                } else {
-                    obj = toBeSorted[key];
-                }
-                sorted[key] = obj;
+            if (operation.Url.indexOf("serverFarms/{name}") !== -1) {
+                operation.Url = operation.Url.replace("serverFarms/{name}", "serverFarms/{webHostingPlanName}");
             }
-        }
-        for (var key in toBeSorted) {
-            if (toBeSorted.hasOwnProperty(key) && sorted[key] === undefined) {
-                sorted[key] = toBeSorted[key]
+            if (operation.Url.indexOf("resourcegroups") !== -1) {
+                operation.Url = operation.Url.replace("resourcegroups", "resourceGroups");
             }
-        }
-        return sorted;
-    }
-
-    function mergeObject(source: any, target: any): any {
-        for (var sourceProperty in source) {
-            if (source.hasOwnProperty(sourceProperty) && target.hasOwnProperty(sourceProperty)) {
-                if (!isEmptyObjectorArray(source[sourceProperty]) && (typeof source[sourceProperty] === "object") && !Array.isArray(source[sourceProperty])) {
-                    mergeObject(source[sourceProperty], target[sourceProperty]);
-                } else if (Array.isArray(source[sourceProperty]) && Array.isArray(target[sourceProperty])) {
-                    var targetModel = target[sourceProperty][0];
-                    target[sourceProperty] = source[sourceProperty];
-                    target[sourceProperty].push(targetModel);
-                } else {
-                    target[sourceProperty] = source[sourceProperty];
-                }
-            } else if (source.hasOwnProperty(sourceProperty)) {
-                target[sourceProperty] = source[sourceProperty];
+            if (operation.Url.endsWith("/")) {
+                operation.Url = operation.Url.substring(0, operation.Url.length - 1);
             }
-        }
-        return target;
-    }
-
-    function stringify(object: any): string {
-        return JSON.stringify(object, undefined, 2)
-    }
-
-    function getDocumentationFlatArray(editorData: any, doc: any) {
-        var docArray: any[] = [];
-        if (doc) {
-            doc = (doc.properties ? doc.properties : (doc.value ? doc.value[0].properties : {}));
+            return operation;
         }
 
-        if (editorData && doc) {
-            editorData = (editorData.properties ? editorData.properties : ((editorData.value && editorData.value.length > 0) ? editorData.value[0].properties : {}));
-            var set: any = {};
-            for (var prop in editorData) {
-                if (editorData.hasOwnProperty(prop) && doc[prop]) {
-                    docArray.push({
-                        name: prop,
-                        doc: doc[prop]
-                    });
-                    set[prop] = 1;
+        function buildResourcesDefinitionsTable(operation: IMetadataObject, url?: string) {
+            url = (operation ? operation.Url : url);
+            url = url.replace(/{.*?}/g, "{name}");
+            var segments = url.split("/").filter(a => a.length !== 0);
+            var resourceName = segments.pop();
+            var addedElement: IResourceDefinition;
+
+            if (resourceName === "list" && operation && operation.HttpMethod === "POST") {
+                // handle resources that has a "secure GET"
+                setParent(url, "GETPOST", operation.RequestBody, operation.RequestBodyDoc, operation.ApiVersion);
+                return;
+            } else if (operation && (operation.MethodName.startsWith("Create") || operation.MethodName.startsWith("BeginCreate") || operation.MethodName.startsWith("Put")) && operation.HttpMethod === "PUT") {
+                // handle resources that has a CreateOrUpdate
+                setParent(url, "CREATE", operation.RequestBody, operation.RequestBodyDoc);
+                if (operation.MethodName.indexOf("Updat") === -1) {
+                    return;
                 }
             }
 
-            for (var prop in doc) {
-                if (doc.hasOwnProperty(prop) && !set[prop]) {
-                    docArray.push({
-                        name: prop,
-                        doc: doc[prop]
-                    });
-                }
-            }
-            delete set;
-
-        } else {
-            docArray.push({
-                name: "message",
-                doc: "No documentation available"
-            });
-        }
-
-        return flattenArray(docArray);
-    }
-
-    function flattenArray(array: any[]): any[] {
-        for (var i = 0; i < array.length; i++) {
-            if (typeof array[i].doc !== "string") {
-                var flat = flattenObject(array[i].name, array[i].doc);
-                var first = array.slice(0, i);
-                var end = array.slice(i + 1);
-                array = first.concat(flat).concat(end);
-                i += flat.length - 1;
-            }
-        }
-        return array;
-    }
-
-    function flattenObject(prefix: string, object: any): any[] {
-        var flat: any[] = [];
-        if (typeof object === "string") {
-            flat.push({
-                name: prefix,
-                doc: object
-            });
-        } else if (Array.isArray(object)) {
-            flat = flat.concat(flattenObject(prefix, object[0]));
-        } else if (isEmptyObjectorArray(object)) {
-            flat.push({
-                name: prefix,
-                doc: ""
-            });
-        } else {
-            for (var prop in object) {
-                if (object.hasOwnProperty(prop)) {
-                    if (typeof object[prop] === "string") {
-                        flat.push({
-                            name: prefix + "." + prop,
-                            doc: object[prop]
-                        });
-                    } else if (Array.isArray(object[prop]) && object[prop].length > 0) {
-                        flat = flat.concat(flattenObject(prefix + "." + prop, object[prop][0]));
-                    } else if (typeof object[prop] === "object") {
-                        flat = flat.concat(flattenObject(prefix + "." + prop, object[prop]));
-                    } else {
-                        flat.push({
-                            name: prefix,
-                            doc: object
-                        });
+            //set the element itself
+            var elements = $scope.resourcesDefinitionsTable.filter(r => r.url.toLowerCase() === url.toLowerCase());
+            if (elements.length === 1) {
+                //it's there, update it's actions
+                if (operation) {
+                    elements[0].requestBody = (elements[0].requestBody ? elements[0].requestBody : operation.RequestBody);
+                    elements[0].apiVersion = operation.ApiVersion;
+                    if (elements[0].actions.filter(c => c === operation.HttpMethod).length === 0) {
+                        elements[0].actions.push(operation.HttpMethod);
+                    }
+                    if (operation.HttpMethod === "GET") {
+                        elements[0].responseBodyDoc = operation.ResponseBodyDoc
+                    } else if (operation.HttpMethod === "PUT") {
+                        elements[0].requestBodyDoc = operation.RequestBodyDoc;
                     }
                 }
-            }
-        }
-        return flat;
-    }
-
-    function isItemOf(branch: ITreeBranch, elementType: string): boolean {
-        var parent = $scope.treeControl.get_parent_branch(branch);
-        return (parent && parent.resourceDefinition.resourceName === elementType);
-    }
-
-    function showExpandingTreeItemIcon(row: any, branch: ITreeBranch): string {
-        var originalTreeIcon = row ? row.tree_icon : "icon-plus  glyphicon glyphicon-plus fa fa-plus";
-        $(document.getElementById("expand-icon-" + branch.uid)).removeClass(originalTreeIcon).addClass("fa fa-refresh fa-spin");
-        return originalTreeIcon;
-    }
-
-    function endExpandingTreeItem(branch: ITreeBranch, originalTreeIcon: string) {
-        $(document.getElementById("expand-icon-" + branch.uid)).removeClass("fa fa-spinner fa-spin").addClass(originalTreeIcon);
-    }
-
-    function getProvidersFilter(branch: ITreeBranch): any[] {
-        if (!branch) return;
-        if (branch.providersFilter) return branch.providersFilter;
-        return getProvidersFilter($scope.treeControl.get_parent_branch(branch));
-    }
-
-    function userHttp(config: ng.IRequestConfig, success: ng.IHttpPromiseCallback<any>, error: ng.IHttpPromiseCallback<any>, always: () => any, event: Event, confirmed?: boolean) {
-        var method = (config.data ? config.data.HttpMethod : config.method);
-        var url = (config.data ? config.data.Url : config.url);
-        if ($scope.readOnlyMode) {
-            if (method !== "GET" && !(method === "POST" && url.split('/').last() === "list")) {
-                if (event) {
-                    var clickedButton = $(event.currentTarget);
-                    var readonlyConfirmation = $("#readonly-confirm-box");
-                    // I don't know why the top doesn't center the value for the small buttons but does for the large ones
-                    // add an 8px offset if the button outer height < 40
-                    var offset = (clickedButton.outerHeight() < 40 ? 8 : 0);
-                    readonlyConfirmation.css({ top: (clickedButton.offset().top - clickedButton.outerHeight(true) - offset) + 'px', left: (clickedButton.offset().left + clickedButton.outerWidth()) + 'px' });
-                    $("#dark-blocker").show();
-                    readonlyConfirmation.show();
-                }
-                return decoratePromise($q.reject()).finally(always);
-            }
-        } else if (method === "DELETE" && !confirmed) {
-            var deleteButton = $(event.currentTarget);
-            var deleteConfirmation = $("#delete-confirm-box");
-            deleteConfirmation.css({ top: (deleteButton.offset().top - (((deleteButton.outerHeight() + 10) / 2))) + 'px', left: (deleteButton.offset().left + deleteButton.outerWidth()) + 'px' });
-            $("#yes-delete-confirm").off("click").click((e) => {
-                e.stopPropagation();
-                e.preventDefault();
-                $scope.hideConfirm();
-                _invokeAction({
-                    name: "",
-                    httpMethod: "DELETE",
-                    url: url
-                }, e, true /*confirmed*/);
-            });
-            $("#dark-blocker").show();
-            deleteConfirmation.show();
-            return decoratePromise($q.when().finally(always));
-        } else {
-            return $http(config).success(success).error(error).finally(always);
-        }
-    }
-
-    function decoratePromise(promise: ng.IPromise<any>) {
-        (<any> promise).success = (fn: Function) => {
-            promise.then((response: any) => {
-                fn(response);
-            });
-            return promise;
-        };
-
-        (<any>promise).error = (fn: Function) => {
-            promise.then(null,(response) => {
-                fn(response);
-            });
-            return promise;
-        };
-        return promise;
-    }
-
-    function findCommonAncestor(armIdA: string, armIdB: string): string {
-        var getTokensFromId = (url: string): string[]=> {
-            url = url.toLowerCase();
-            var removeTo = 0;   // default is to remove first empty token "/subscriptions/3b94e3c2-9f5b-4a1e-9999-3e0945b8…a9/resourceGroups/brandoogroup3/providers/Microsoft.Web/sites/brandoosite3"
-            if (url.startsWith("http")) {
-                // "https://management.azure.com/subscriptions/3b94e3c2-9f5b-4a1e-9999-3e0945b8…a9/resourceGroups/brandoogroup3/providers/Microsoft.Web/sites/brandoosite3"
-                // if start with "http/https", we will need to ignore the host name
-                removeTo = 2;
-            }
-
-            var tokens = url.split('/');
-            tokens.remove(0, removeTo);
-            return tokens;
-        };
-
-        var tokensA = getTokensFromId(armIdA);
-        var tokensB = getTokensFromId(armIdB);
-        var len = Math.min(tokensA.length, tokensB.length);
-        var commonAncestor = "";
-        for (var i = 0; i < len; i++) {
-            if (tokensA[i] === tokensB[i]) {
-                commonAncestor += "/" + tokensA[i];
             } else {
-                break;
+                addedElement = {
+                    resourceName: resourceName,
+                    children: undefined,
+                    actions: (operation ? [operation.HttpMethod] : []),
+                    url: url,
+                    requestBody: operation ? operation.RequestBody : {},
+                    requestBodyDoc: operation ? operation.RequestBodyDoc : {},
+                    responseBodyDoc: operation ? operation.ResponseBodyDoc : {},
+                    query: operation ? operation.Query : [],
+                    apiVersion: operation && operation.ApiVersion ? operation.ApiVersion : undefined
+                };
+                $scope.resourcesDefinitionsTable.push(addedElement);
             }
-        }
 
-        return commonAncestor;
-    }
-    function getTreeBranchDataOverrides(): ITreeBranchDataOverrides[] {
-        // Define any overrides for display label and sort key/order for tree nodes
-        // Rule matching is performing by checking whether the childDefinition.url ends with the childDefinitionUrlSuffix
-        //  - getLabel is called to provide the node label. Provide a function that takes the node data and csmName and returns the label
-        //  - getSortKey is called to provide the node sort key. Provide a function that takes the node data and label and returns the sort key
-        //  - sortOrder: 1 to sort ascending, -1 to sort descending 
-        return [
-            {
-                childDefinitionUrlSuffix: "providers/Microsoft.Resources/deployments/{name}", // deployments
-                getLabel: null,
-                getSortKey: (d: any, label: string) => d.properties.timestamp,
-                getIconNameOverride: (d: any) => {
-                    switch (d.properties.provisioningState) {
-                        case "Succeeded": return "glyphicon glyphicon-ok-circle";
-                        case "Running": return "glyphicon glyphicon-play-circle";
-                        case "Failed": return "glyphicon glyphicon-remove-circle";
-                        default: return null;
-                    }
-                },
-                sortOrder: -1
-            },
-            {
-                childDefinitionUrlSuffix: "providers/Microsoft.Resources/deployments/{name}/operations/{name}", // operations
-                getLabel: (d: any, csmName: string) => {
-                    if (d.properties.targetResource !== undefined && d.properties.targetResource.resourceName !== undefined) {
-                        return d.properties.targetResource.resourceName + " (" + d.properties.targetResource.resourceType + ")";
+            // set the parent recursively
+            setParent(url);
+            return addedElement;
+        };
+
+        function setParent(url: string, action?: string, requestBody?: any, requestBodyDoc?: any, apiVersion?: string) {
+            var segments = url.split("/").filter(a => a.length !== 0);
+            var resourceName = segments.pop();
+            var parentName = url.substring(0, url.lastIndexOf("/"));
+            if (parentName === undefined || parentName === "" || resourceName === undefined) return;
+            var parents = $scope.resourcesDefinitionsTable.filter(rd => rd.url.toLowerCase() === parentName.toLowerCase());
+            var parent: IResourceDefinition;
+            if (parents.length === 1) {
+                parent = parents[0];
+                if (resourceName.match(/\{.*\}/g)) {
+                    // this means the parent.children should either be an undefined, or a string.
+                    // if it's anything else assert! because that means we have a mistake in our assumptions
+                    if (parent.children === undefined || typeof parent.children === "string") {
+                        parent.children = resourceName;
                     } else {
-                        return d.properties.provisioningOperation + " (" + d.operationId + ")"
+                        console.log("ASSERT1, typeof parent.children: " + typeof parent.children)
                     }
-                },
-                getSortKey: (d: any, label: string) => d.properties.timestamp,
-                getIconNameOverride: (d: any) => {
-                    switch (d.properties.provisioningState) {
-                        case "Succeeded": return "glyphicon glyphicon-ok-circle";
-                        case "Running": return "glyphicon glyphicon-play-circle";
-                        case "Failed": return "glyphicon glyphicon-remove-circle";
-                        default: return null;
+                } else if (resourceName !== "list") {
+                    // this means that the resource is a pre-defined one. the parent.children should be undefined or array
+                    // if it's anything else assert! because that means we have a mistake in out assumptions
+                    if (parent.children === undefined) {
+                        parent.children = [resourceName];
+                    } else if (Array.isArray(parent.children)) {
+                        if ((<string[]>parent.children).filter(c => c === resourceName).length === 0) {
+                            (<string[]>parent.children).push(resourceName);
+                        }
+                    } else {
+                        parent.children = [resourceName];
+                        console.log("ASSERT2, typeof parent.children: " + typeof parent.children)
                     }
-                },
-                sortOrder: -1
-            }              
-        ];
-    }
-    function getTreeBranchProjection(childDefinition) : ITreeBranchDataOverrides {
-        // look up to see whether the current node in the tree has any overrides for the
-        // display label or sort key/order
-        var overrides = $scope.treeBranchDataOverrides
-            .filter(t=> childDefinition.url.endsWith(t.childDefinitionUrlSuffix));
-
-        var override = overrides.length > 0
-            ? overrides[0]
-            : {
-                childDefinitionUrlSuffix: null,
-                getLabel: null,
-                getSortKey: null,
-                getIconNameOverride: null,
-                sortOrder: 1
+                }
+            } else {
+                //this means the parent is not in the array. Add it
+                parent = buildResourcesDefinitionsTable(undefined, url.substring(0, url.lastIndexOf("/")));
+                setParent(url);
             }
 
-        // Apply default behaviors
-        //  - label uses displayname with a fallback to csmName
-        //  - sort is by label
-        if (override.getLabel == null) {
-            override.getLabel = (d: any, csmName: string) => (d.displayName ? d.displayName : csmName);
+            if (action && parent && parent.actions.filter(c => c === action).length === 0) {
+                parent.actions.push(action);
+            }
+
+            if (requestBody && parent && !parent.requestBody) {
+                parent.requestBody = requestBody;
+            }
+
+            if (requestBodyDoc && parent && !parent.requestBodyDoc) {
+                parent.requestBodyDoc = requestBodyDoc;
+            }
+
+            if (apiVersion && parent && !parent.apiVersion) {
+                parent.apiVersion = apiVersion;
+            }
         }
-        if (override.getSortKey == null) {
-            override.getSortKey = (d: any, label: string) => label;
+
+        function fixWidths(event: Event) {
+            if (!event) return;
+            var anchor = $(event.currentTarget);
+            var span = $(event.currentTarget).find("span");
+            var width = span.width() + parseInt(span.css("left"), 10) + 37;
+            anchor.width((width < 280 ? 280 : width) - 20);
         }
-        if (override.getIconNameOverride == null) {
-            override.getIconNameOverride = (d: any) => null;
+
+        function syntaxHighlight(json: any) {
+            if (typeof json === "string") return escapeHtmlEntities(json);
+            var str = stringify(json);
+            str = escapeHtmlEntities(str);
+            return str.replace(/("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?)/g, (match) => {
+                var cls = 'number';
+                if (/^"/.test(match)) {
+                    if (/:$/.test(match)) {
+                        cls = 'key';
+                    } else {
+                        cls = 'string';
+                    }
+                } else if (/true|false/.test(match)) {
+                    cls = 'boolean';
+                } else if (/null/.test(match)) {
+                    cls = 'null';
+                }
+                if (cls === 'string' && ((match.slice(0, "\"http://".length) == "\"http://") || (match.slice(0, "\"https://".length) == "\"https://"))) {
+                    match = match.replace("/api/", "/");
+                    return '<span><a class="json-link" target="_blank" href=' + match + '>' + match + '</a></span>';
+                } else {
+                    return '<span class="' + cls + '">' + match + '</span>';
+                }
+            });
         }
-        return override;
-    }
-}])
+
+        function escapeHtmlEntities(str: string) {
+            return $('<div/>').text(str).html();
+        }
+
+        function selectiveUrlencode(url: string) {
+            return url.replace(/\#/g, '%23').replace(/\s/g, '%20');
+        }
+
+        function getRerouceGroupNameFromWebSpaceName(webSpaceName: string) {
+            webSpaceName = webSpaceName.toLowerCase();
+            if (!webSpaceName.endsWith("webspace")) {
+                return undefined;
+            }
+
+            // strip ending webspace
+            var ws = webSpaceName.substring(0, webSpaceName.length - 8);
+            var index = ws.lastIndexOf('-');
+            if (index < 0) {
+                return "Default-Web-" + ws;
+            }
+            else {
+                return ws.substring(0, index);
+            }
+        }
+
+        function isEmptyObjectorArray(obj: any) {
+            if (typeof obj === "number" || typeof obj === "boolean") return false;
+            if ($.isEmptyObject(obj)) return true;
+            if (obj === null || obj === "" || obj.length === 0) return true;
+            return false;
+        }
+
+        function cleanObject(obj: any) {
+            var hadProperties = (obj.properties !== undefined);
+            recursiveCleanObject(obj);
+            if (hadProperties && !obj.properties) {
+                obj.properties = {};
+            }
+        }
+
+        function recursiveCleanObject(obj: any) {
+            for (var property in obj) {
+                if (obj.hasOwnProperty(property)) {
+                    if (typeof obj[property] === "string" && (/^\(.*\)$/.test(obj[property]))) {
+                        delete obj[property];
+                    } else if (Array.isArray(obj[property])) {
+                        var hadElements = obj[property].length > 0;
+                        obj[property] = obj[property].filter((element: any) => {
+                            if (typeof element === "string" && (/^\(.*\)$/.test(element))) {
+                                return false
+                            } else if (typeof element === "object" && !$.isEmptyObject(element)) {
+                                recursiveCleanObject(element);
+                            } else if (typeof element === "object" && $.isEmptyObject(element)) {
+                                return false;
+                            }
+                            if ($.isPlainObject(element) && $.isEmptyObject(element)) return false;
+                            return true;
+                        });
+                        if (hadElements && obj[property].length === 0) delete obj[property];
+                    } else if (typeof obj[property] === "object" && !$.isEmptyObject(obj[property])) {
+                        recursiveCleanObject(obj[property]);
+                        if ($.isEmptyObject(obj[property])) delete obj[property];
+                    } else if (typeof obj[property] === "object" && $.isEmptyObject(obj[property])) {
+                        delete obj[property];
+                    }
+                }
+            }
+        }
+
+        function sortByObject(toBeSorted: any, toSortBy: any): any {
+            if (toBeSorted === toSortBy) return toBeSorted;
+            var sorted: any = {};
+            for (var key in toSortBy) {
+                if (toSortBy.hasOwnProperty(key)) {
+                    var obj: any;
+                    if (typeof toSortBy[key] === "object" && !Array.isArray(toSortBy[key]) && toSortBy[key] != null) {
+                        obj = sortByObject(toBeSorted[key], toSortBy[key]);
+                    } else {
+                        obj = toBeSorted[key];
+                    }
+                    sorted[key] = obj;
+                }
+            }
+            for (var key in toBeSorted) {
+                if (toBeSorted.hasOwnProperty(key) && sorted[key] === undefined) {
+                    sorted[key] = toBeSorted[key]
+                }
+            }
+            return sorted;
+        }
+
+        function mergeObject(source: any, target: any): any {
+            for (var sourceProperty in source) {
+                if (source.hasOwnProperty(sourceProperty) && target.hasOwnProperty(sourceProperty)) {
+                    if (!isEmptyObjectorArray(source[sourceProperty]) && (typeof source[sourceProperty] === "object") && !Array.isArray(source[sourceProperty])) {
+                        mergeObject(source[sourceProperty], target[sourceProperty]);
+                    } else if (Array.isArray(source[sourceProperty]) && Array.isArray(target[sourceProperty])) {
+                        var targetModel = target[sourceProperty][0];
+                        target[sourceProperty] = source[sourceProperty];
+                        target[sourceProperty].push(targetModel);
+                    } else {
+                        target[sourceProperty] = source[sourceProperty];
+                    }
+                } else if (source.hasOwnProperty(sourceProperty)) {
+                    target[sourceProperty] = source[sourceProperty];
+                }
+            }
+            return target;
+        }
+
+        function stringify(object: any): string {
+            return JSON.stringify(object, undefined, 2)
+        }
+
+        function getDocumentationFlatArray(editorData: any, doc: any) {
+            var docArray: any[] = [];
+            if (doc) {
+                doc = (doc.properties ? doc.properties : (doc.value ? doc.value[0].properties : {}));
+            }
+
+            if (editorData && doc) {
+                editorData = (editorData.properties ? editorData.properties : ((editorData.value && editorData.value.length > 0) ? editorData.value[0].properties : {}));
+                var set: any = {};
+                for (var prop in editorData) {
+                    if (editorData.hasOwnProperty(prop) && doc[prop]) {
+                        docArray.push({
+                            name: prop,
+                            doc: doc[prop]
+                        });
+                        set[prop] = 1;
+                    }
+                }
+
+                for (var prop in doc) {
+                    if (doc.hasOwnProperty(prop) && !set[prop]) {
+                        docArray.push({
+                            name: prop,
+                            doc: doc[prop]
+                        });
+                    }
+                }
+                delete this.set;
+
+            } else {
+                docArray.push({
+                    name: "message",
+                    doc: "No documentation available"
+                });
+            }
+
+            return flattenArray(docArray);
+        }
+
+        function flattenArray(array: any[]): any[] {
+            for (var i = 0; i < array.length; i++) {
+                if (typeof array[i].doc !== "string") {
+                    var flat = flattenObject(array[i].name, array[i].doc);
+                    var first = array.slice(0, i);
+                    var end = array.slice(i + 1);
+                    array = first.concat(flat).concat(end);
+                    i += flat.length - 1;
+                }
+            }
+            return array;
+        }
+
+        function flattenObject(prefix: string, object: any): any[] {
+            var flat: any[] = [];
+            if (typeof object === "string") {
+                flat.push({
+                    name: prefix,
+                    doc: object
+                });
+            } else if (Array.isArray(object)) {
+                flat = flat.concat(flattenObject(prefix, object[0]));
+            } else if (isEmptyObjectorArray(object)) {
+                flat.push({
+                    name: prefix,
+                    doc: ""
+                });
+            } else {
+                for (var prop in object) {
+                    if (object.hasOwnProperty(prop)) {
+                        if (typeof object[prop] === "string") {
+                            flat.push({
+                                name: prefix + "." + prop,
+                                doc: object[prop]
+                            });
+                        } else if (Array.isArray(object[prop]) && object[prop].length > 0) {
+                            flat = flat.concat(flattenObject(prefix + "." + prop, object[prop][0]));
+                        } else if (typeof object[prop] === "object") {
+                            flat = flat.concat(flattenObject(prefix + "." + prop, object[prop]));
+                        } else {
+                            flat.push({
+                                name: prefix,
+                                doc: object
+                            });
+                        }
+                    }
+                }
+            }
+            return flat;
+        }
+
+        function isItemOf(branch: ITreeBranch, elementType: string): boolean {
+            var parent = $scope.treeControl.get_parent_branch(branch);
+            return (parent && parent.resourceDefinition.resourceName === elementType);
+        }
+
+        function showExpandingTreeItemIcon(row: any, branch: ITreeBranch): string {
+            var originalTreeIcon = row ? row.tree_icon : "icon-plus  glyphicon glyphicon-plus fa fa-plus";
+            $(document.getElementById("expand-icon-" + branch.uid)).removeClass(originalTreeIcon).addClass("fa fa-refresh fa-spin");
+            return originalTreeIcon;
+        }
+
+        function endExpandingTreeItem(branch: ITreeBranch, originalTreeIcon: string) {
+            $(document.getElementById("expand-icon-" + branch.uid)).removeClass("fa fa-spinner fa-spin").addClass(originalTreeIcon);
+        }
+
+        function getProvidersFilter(branch: ITreeBranch): any[] {
+            if (!branch) return;
+            if (branch.providersFilter) return branch.providersFilter;
+            return getProvidersFilter($scope.treeControl.get_parent_branch(branch));
+        }
+
+        function userHttp(config: ng.IRequestConfig, success: ng.IHttpPromiseCallback<any>, error: ng.IHttpPromiseCallback<any>, always: () => any, event: Event, confirmed?: boolean) {
+            var method = (config.data ? config.data.HttpMethod : config.method);
+            var url = (config.data ? config.data.Url : config.url);
+            if ($scope.readOnlyMode) {
+                if (method !== "GET" && !(method === "POST" && url.split('/').last() === "list")) {
+                    if (event) {
+                        var clickedButton = $(event.currentTarget);
+                        var readonlyConfirmation = $("#readonly-confirm-box");
+                        // I don't know why the top doesn't center the value for the small buttons but does for the large ones
+                        // add an 8px offset if the button outer height < 40
+                        var offset = (clickedButton.outerHeight() < 40 ? 8 : 0);
+                        readonlyConfirmation.css({ top: (clickedButton.offset().top - clickedButton.outerHeight(true) - offset) + 'px', left: (clickedButton.offset().left + clickedButton.outerWidth()) + 'px' });
+                        $("#dark-blocker").show();
+                        readonlyConfirmation.show();
+                    }
+                    return decoratePromise($q.reject()).finally(always);
+                }
+            } else if (method === "DELETE" && !confirmed) {
+                var deleteButton = $(event.currentTarget);
+                var deleteConfirmation = $("#delete-confirm-box");
+                deleteConfirmation.css({ top: (deleteButton.offset().top - (((deleteButton.outerHeight() + 10) / 2))) + 'px', left: (deleteButton.offset().left + deleteButton.outerWidth()) + 'px' });
+                $("#yes-delete-confirm").off("click").click((e) => {
+                    e.stopPropagation();
+                    e.preventDefault();
+                    $scope.hideConfirm();
+                    _invokeAction({
+                        name: "",
+                        httpMethod: "DELETE",
+                        url: url
+                    }, e, true /*confirmed*/);
+                });
+                $("#dark-blocker").show();
+                deleteConfirmation.show();
+                return decoratePromise($q.when().finally(always));
+            } else {
+                return $http(config).success(success).error(error).finally(always);
+            }
+        }
+
+        function decoratePromise(promise: ng.IPromise<any>) {
+            (<any>promise).success = (fn: Function) => {
+                promise.then((response: any) => {
+                    fn(response);
+                });
+                return promise;
+            };
+
+            (<any>promise).error = (fn: Function) => {
+                promise.then(null, (response) => {
+                    fn(response);
+                });
+                return promise;
+            };
+            return promise;
+        }
+
+        function findCommonAncestor(armIdA: string, armIdB: string): string {
+            var getTokensFromId = (url: string): string[] => {
+                url = url.toLowerCase();
+                var removeTo = 0;   // default is to remove first empty token "/subscriptions/3b94e3c2-9f5b-4a1e-9999-3e0945b8…a9/resourceGroups/brandoogroup3/providers/Microsoft.Web/sites/brandoosite3"
+                if (url.startsWith("http")) {
+                    // "https://management.azure.com/subscriptions/3b94e3c2-9f5b-4a1e-9999-3e0945b8…a9/resourceGroups/brandoogroup3/providers/Microsoft.Web/sites/brandoosite3"
+                    // if start with "http/https", we will need to ignore the host name
+                    removeTo = 2;
+                }
+
+                var tokens = url.split('/');
+                tokens.remove(0, removeTo);
+                return tokens;
+            };
+
+            var tokensA = getTokensFromId(armIdA);
+            var tokensB = getTokensFromId(armIdB);
+            var len = Math.min(tokensA.length, tokensB.length);
+            var commonAncestor = "";
+            for (var i = 0; i < len; i++) {
+                if (tokensA[i] === tokensB[i]) {
+                    commonAncestor += "/" + tokensA[i];
+                } else {
+                    break;
+                }
+            }
+
+            return commonAncestor;
+        }
+        function getTreeBranchDataOverrides(): ITreeBranchDataOverrides[] {
+            // Define any overrides for display label and sort key/order for tree nodes
+            // Rule matching is performing by checking whether the childDefinition.url ends with the childDefinitionUrlSuffix
+            //  - getLabel is called to provide the node label. Provide a function that takes the node data and csmName and returns the label
+            //  - getSortKey is called to provide the node sort key. Provide a function that takes the node data and label and returns the sort key
+            //  - sortOrder: 1 to sort ascending, -1 to sort descending 
+            return [
+                {
+                    childDefinitionUrlSuffix: "providers/Microsoft.Resources/deployments/{name}", // deployments
+                    getLabel: null,
+                    getSortKey: (d: any, label: string) => d.properties.timestamp,
+                    getIconNameOverride: (d: any) => {
+                        switch (d.properties.provisioningState) {
+                            case "Succeeded": return "glyphicon glyphicon-ok-circle";
+                            case "Running": return "glyphicon glyphicon-play-circle";
+                            case "Failed": return "glyphicon glyphicon-remove-circle";
+                            default: return null;
+                        }
+                    },
+                    sortOrder: -1
+                },
+                {
+                    childDefinitionUrlSuffix: "providers/Microsoft.Resources/deployments/{name}/operations/{name}", // operations
+                    getLabel: (d: any, csmName: string) => {
+                        if (d.properties.targetResource !== undefined && d.properties.targetResource.resourceName !== undefined) {
+                            return d.properties.targetResource.resourceName + " (" + d.properties.targetResource.resourceType + ")";
+                        } else {
+                            return d.properties.provisioningOperation + " (" + d.operationId + ")"
+                        }
+                    },
+                    getSortKey: (d: any, label: string) => d.properties.timestamp,
+                    getIconNameOverride: (d: any) => {
+                        switch (d.properties.provisioningState) {
+                            case "Succeeded": return "glyphicon glyphicon-ok-circle";
+                            case "Running": return "glyphicon glyphicon-play-circle";
+                            case "Failed": return "glyphicon glyphicon-remove-circle";
+                            default: return null;
+                        }
+                    },
+                    sortOrder: -1
+                }
+            ];
+        }
+        function getTreeBranchProjection(childDefinition): ITreeBranchDataOverrides {
+            // look up to see whether the current node in the tree has any overrides for the
+            // display label or sort key/order
+            var overrides = $scope.treeBranchDataOverrides
+                .filter(t => childDefinition.url.endsWith(t.childDefinitionUrlSuffix));
+
+            var override = overrides.length > 0
+                ? overrides[0]
+                : {
+                    childDefinitionUrlSuffix: null,
+                    getLabel: null,
+                    getSortKey: null,
+                    getIconNameOverride: null,
+                    sortOrder: 1
+                }
+
+            // Apply default behaviors
+            //  - label uses displayname with a fallback to csmName
+            //  - sort is by label
+            if (override.getLabel == null) {
+                override.getLabel = (d: any, csmName: string) => (d.displayName ? d.displayName : csmName);
+            }
+            if (override.getSortKey == null) {
+                override.getSortKey = (d: any, label: string) => label;
+            }
+            if (override.getIconNameOverride == null) {
+                override.getIconNameOverride = (d: any) => null;
+            }
+            return override;
+        }
+    }])
     .config(($locationProvider: ng.ILocationProvider) => {
-    $locationProvider.html5Mode(true);
+        $locationProvider.html5Mode(true);
     });
 
-function getPowerShellFromResource(value: ISelelctHandlerReturn, actions: IAction[]): string {
-    var returnString = "# PowerShell equivalent script\n\n";
-    var resourceInfo = GetResourceTypeAndName(value);
-    var children = value.resourceDefinition.children;
+function getPowerShellScriptsForResource(value: ISelectHandlerReturn, actions: IAction[]): string {
+    var script = "# PowerShell equivalent script\n\n";
 
-    // add GET related cmdlet if available
-    var getCmdlet = "Get-AzureRmResource ";
-    var apiVersion = value.resourceDefinition.apiVersion;
-    var isCollection = "";
-    if (value.httpMethod.toLowerCase().indexOf("get") != -1) {
-        returnString += "# GET " + GetActionName(value.url) + "\n";
-        if (typeof children === "string" && !Array.isArray(children) && value.url.split("/").length > 7) {
-            isCollection = " -isCollection";
-        }
-        returnString += getCmdlet + resourceInfo + isCollection + " -ApiVersion " + apiVersion + "\n\n";
+    let urlParser = new ARMUrlParser(value, actions);
+    let parameterResolver = new PSCmdletParameterResolver(urlParser);
+    let scriptGenerator = new PsScriptGenerator(parameterResolver);
+    for (let cmd of parameterResolver.getSupportedCommands()) {
+        script += scriptGenerator.getScript(cmd);
     }
-    else if (value.httpMethod.toLowerCase().indexOf("post") != -1 && value.url.indexOf("list") != -1) {
-        returnString += "# List " + GetActionName(value.url.replace("/list", "")) + "\n";
-        returnString += "$resource = Invoke-AzureRmResourceAction " + resourceInfo + " -Action list -ApiVersion " + value.resourceDefinition.apiVersion + " -Force\n";
-        returnString += "$resource.Properties\n\n";
-    }
-
-    // add SET related cmdlet if available
-    if (value.resourceDefinition.actions.some(a => (a === "PATCH" || a === "PUT"))) {
-        returnString += "# SET " + GetActionName(value.url) + "\n";
-        returnString += "$PropertiesObject = @{\n\t#Property = value;\n}\n";
-
-        // handle secure GET
-        if (value.resourceDefinition.actions.includes("GET")) {
-            returnString += "Set-AzureRmResource -PropertyObject $PropertiesObject " + resourceInfo + " -ApiVersion " + value.resourceDefinition.apiVersion + " -Force\n\n";
-        }
-        else {
-            returnString += "New-AzureRmResource -PropertyObject $PropertiesObject " + resourceInfo + " -ApiVersion " + value.resourceDefinition.apiVersion + " -Force\n\n";
-        }
-    }
-
-    // add CREATE related cmdlet if available
-    if (value.resourceDefinition.actions.includes("CREATE")) {
-        returnString += "# CREATE " + GetActionName(value.url) + "\n";
-        returnString += "$ResourceLocation = \"West US\"\n$ResourceName = \"New" + GetResourceName(value.url) + "\"\n$PropertiesObject = @{\n\t#Property = value;\n}\n";
-        returnString += "New-AzureRmResource -ResourceName $ResourceName -Location $ResourceLocation -PropertyObject $PropertiesObject " + resourceInfo + " -ApiVersion " + value.resourceDefinition.apiVersion + " -Force\n\n";
-    }
-
-    // add ACTIONS related Cmdlets if available
-    if (actions.length > 0) {
-        returnString += "# Actions available on that object\n\n";
-        actions.forEach(action => {
-            if (action.httpMethod.toLocaleLowerCase() === "delete") {
-                returnString += "# Delete " + GetActionName(action.url) + "\n";
-                returnString += "Remove-AzureRmResource " + resourceInfo + " -ApiVersion " + value.resourceDefinition.apiVersion + " -Force\n\n";
-            }
-            else if (action.httpMethod.toLocaleLowerCase() === "post") {
-                returnString += "# Action " + GetActionName(action.url) + "\n";
-                if (action.requestBody) {
-                    returnString += "$ParametersObject = " + GETPSObjectFromJSON(action.requestBody, 0) + "\n";
-                }
-                returnString += "Invoke-AzureRmResourceAction " + resourceInfo + " -Action " + action.name + (action.requestBody ? " -Parameters $ParametersObject": "") + " -ApiVersion " + value.resourceDefinition.apiVersion +" -Force\n\n";
-            }
-        })
-    }
-    return returnString;
-}
-
-function GetResourceName(url: string): string {
-    return url.substr(url.lastIndexOf("/")+1, url.length - url.lastIndexOf("/")-2);
-}
-
-function GetActionName(url: string): string {
-    return url.substr(url.lastIndexOf("/") + 1, url.length - url.lastIndexOf("/") - 1);
-}
-
-function GetResourceTypeAndName(value: ISelelctHandlerReturn): string {
-    var url = value.url;
-
-    // handle secure GET
-    if ((value.httpMethod.toLowerCase().indexOf("post") != -1 && value.url.indexOf("list") != -1)) {
-        url = url.replace("/list", "");
-    }
-    var urlParts = url.split("/");
-    if (urlParts.length < 8) return "-ResourceId " + url.replace("https://management.azure.com", "");
-    var result = "-ResourceGroupName ";
-    result += urlParts[6] // set ResourceGroup
-    var resourceType = "", resourceName = "";
-    for (var i = 7; i < urlParts.length ; i += 2) {
-        if (urlParts[i].toLowerCase().indexOf("providers") != 0) {
-            resourceType += urlParts[i] + "/";
-            if (urlParts[i + 1]) resourceName += urlParts[i + 1] + "/"; // in case of odd length of urlparts
-        }
-        else {
-            resourceType += urlParts[i + 1] + "/";
-        }
-    }
-
-    // Remove the trailing slash
-    resourceType = " -ResourceType " + resourceType.substring(0, resourceType.length - 1);
-    // Let's quote resource name, it may contain whitespace or '#'
-    if (resourceName) resourceName = " -ResourceName " + "'" + resourceName.substring(0, resourceName.length - 1) + "'";
-    result += resourceType + resourceName;
-
-    return result;
-}
-
-function GETPSObjectFromJSON(json: string, nestingLevel: number): string {
-    var tabs = "";
-    for (var i = 0; i < nestingLevel; i++) {
-        tabs += "\t";
-    }
-    var jsonObj = JSON.parse(json);
-    if (typeof jsonObj === "string") {
-        return "\"" + jsonObj + "\"";
-    }
-    else if (typeof jsonObj === "boolean") {
-        return jsonObj.toString();
-    }
-    else if (typeof jsonObj === "number") {
-        return jsonObj.toString();
-    }
-    else if (Array.isArray(jsonObj)) {
-        var result = "(\n";
-        for (var i = 0; i < jsonObj.length; i++) {
-            result += tabs + "\t" + GETPSObjectFromJSON(JSON.stringify(jsonObj[i]), nestingLevel + 1) + "\n";
-        }
-        return result + tabs + ")\n";
-    }
-    else if (typeof jsonObj === "object") {
-        var result = "@{\n";
-        for (var prop in jsonObj) {
-            if (jsonObj.hasOwnProperty(prop)) {
-                result += tabs + "\t" + prop + " = " + GETPSObjectFromJSON(JSON.stringify(jsonObj[prop]), nestingLevel + 1) + "\n";
-            }
-        }
-        return result + tabs + "}\n";
-    }
-    return json;
+    return script;
 }
 
 // Global JS fixes
@@ -1757,3 +1635,5 @@ $(document).mouseup((e) => {
         $('#dark-blocker').hide();
     }
 });
+}
+

--- a/ng/models/ISelectHandlerReturn.ts
+++ b/ng/models/ISelectHandlerReturn.ts
@@ -1,4 +1,4 @@
-﻿interface ISelelctHandlerReturn {
+﻿interface ISelectHandlerReturn {
     resourceDefinition: IResourceDefinition;
     data: any;
     url: string;

--- a/ng/test/PowerShellScriptTests.ts
+++ b/ng/test/PowerShellScriptTests.ts
@@ -1,0 +1,1085 @@
+﻿module armExplorer
+{
+    function keyCount(arg: any) {
+        let count : number = 0;
+        for (let key in arg) {
+            count++;
+        }
+        return count;
+    }
+
+    function throwIfObjectNotEqual<T>(expected: T, actual: T) {
+        throwIfNotEqual(keyCount(expected), keyCount(actual));
+        for (let key in expected) {
+            if (typeof expected[key] === 'object') {
+                throwIfObjectNotEqual(expected[key], actual[key]);
+            }
+            else {
+                throwIfNotEqual(expected[key], actual[key]);
+            }
+        }
+    }
+     
+    function throwIfArrayNotEqual<T>(expectedStrings: Array<T>, actualStrings: Array<T>) {
+        if (expectedStrings.length != actualStrings.length) {
+            throw new Error("Expected: " + expectedStrings.length + "\nActual: " + actualStrings.length+"\n");
+        }
+        for (let i in expectedStrings) {
+            throwIfNotEqual(expectedStrings[i], actualStrings[i]);
+        }
+    }
+
+    function throwIfNotEqual<T>(expected: T, actual: T) {
+        if (typeof expected === 'object') {
+            throwIfObjectNotEqual(expected, actual);
+        }
+        else {
+            if (expected !== actual) {
+                throw new Error("Expected: " + expected + "\nActual: " + actual + "\n");
+            }
+        }
+    }
+
+    function throwIfDefined(arg: any) {
+        if (typeof arg === 'undefined')
+            return;
+        throw new Error("Expected: undefined Actual: " + arg);
+    }
+
+    function logSuccess(callerArg: IArguments) {
+        let currentFunction: string = callerArg.callee.toString();
+        console.log(currentFunction.substr(0, currentFunction.indexOf('(')).replace("function", "TEST") + " :PASSED");
+    }
+
+    namespace PsScriptGeneratorTests {
+
+        scriptSubscriptions();
+        scriptSubscriptionsSubId();
+        scriptSubscriptionsSubIdResGroup();
+        scriptResourceIDOnlyWithResourceGroupName();
+        scriptResGrpNameResType();
+        scriptResGrpNameResTypeResName();
+        scriptResGrpNameResTypeResNameSubType1();
+        scriptResGrpNameResTypeResNameSubType1SubName1();
+        scriptResGrpNameResTypeResNameSubType1SubName1SubType2();
+        scriptResGrpNameResTypeResNameSubType1SubName1SubType2SubName2();
+        scriptResGrpNameResTypeResNameSubType1SubName1SubType2SubName2SubType3();
+        scriptResGrpNameResTypeResNameSubType1SubName1SubType2SubName2SubType3SubName3();
+        scriptResourceUrlWithList();
+       
+        function scriptSubscriptions() {
+            let resourceDefinition = {} as IResourceDefinition;
+            resourceDefinition.actions = ["GET"];
+            resourceDefinition.apiVersion = "2014-04-01";
+            resourceDefinition.children = "{name}";
+
+            let value = {} as ISelectHandlerReturn;
+            value.httpMethod = "GET";
+            value.url = "https://management.azure.com/subscriptions";
+            value.resourceDefinition = resourceDefinition;
+
+            let resolver = new PSCmdletParameterResolver(new ARMUrlParser(value,[]));
+            let scriptGenerator = new PsScriptGenerator(resolver);
+            let actualSupportedCommands: Array<RMCommandInfo> = resolver.getSupportedCommands();
+            let expectedScripts = [] as Array<string>;
+            expectedScripts[0] = "# GET subscriptions\nGet-AzureRmResource -ResourceId /subscriptions -ApiVersion 2014-04-01\n\n";
+
+            throwIfNotEqual(expectedScripts.length, actualSupportedCommands.length);
+            let expectedScriptIndex : number = 0;
+            for (let cmdActionPair of actualSupportedCommands) {
+                throwIfNotEqual(expectedScripts[expectedScriptIndex++], scriptGenerator.getScript(cmdActionPair));
+            }
+
+            logSuccess(arguments);
+        }
+
+        function scriptSubscriptionsSubId() {
+            let resourceDefinition = {} as IResourceDefinition;
+            resourceDefinition.actions = ["GET"];
+            resourceDefinition.apiVersion = "2014-04-01";
+            resourceDefinition.children = "{name}";
+
+            let value = {} as ISelectHandlerReturn;
+            value.httpMethod = "GET";
+            value.url = "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000";
+            value.resourceDefinition = resourceDefinition;
+            let resolver = new PSCmdletParameterResolver(new ARMUrlParser(value,[]));
+            let scriptGenerator = new PsScriptGenerator(resolver);
+            let actualSupportedCommands: Array<RMCommandInfo> = resolver.getSupportedCommands();
+            let expectedScripts = [] as Array<string>;
+            expectedScripts[0] = "# GET 00000000-0000-0000-0000-000000000000\nGet-AzureRmResource -ResourceId /subscriptions/00000000-0000-0000-0000-000000000000 -ApiVersion 2014-04-01\n\n";
+            throwIfNotEqual(expectedScripts.length, actualSupportedCommands.length);
+
+            let expectedScriptIndex: number = 0;
+            for (let cmdActionPair of actualSupportedCommands) {
+                throwIfNotEqual(expectedScripts[expectedScriptIndex++], scriptGenerator.getScript(cmdActionPair));
+            }
+
+            logSuccess(arguments);
+        }
+
+        function scriptSubscriptionsSubIdResGroup() {
+            let resourceDefinition = {} as IResourceDefinition;
+            resourceDefinition.actions = ["GET", "CREATE"];
+            resourceDefinition.apiVersion = "2014-04-01";
+            resourceDefinition.children = "{name}";
+
+            let value = {} as ISelectHandlerReturn;
+            value.httpMethod = "GET";
+            value.url = "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups";
+            value.resourceDefinition = resourceDefinition;
+            let resolver = new PSCmdletParameterResolver(new ARMUrlParser(value,[]));
+            let scriptGenerator = new PsScriptGenerator(resolver);
+            let actualSupportedCommands: Array<RMCommandInfo> = resolver.getSupportedCommands();
+
+            let expectedScripts = [] as Array<string>;
+            expectedScripts[0] = "# GET resourceGroups\nGet-AzureRmResource -ResourceId /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups -ApiVersion 2014-04-01\n\n";
+            expectedScripts[1] = '# CREATE resourceGroups\n$ResourceLocation = "West US"\n$ResourceName = "NewresourceGroup"\n\nNew-AzureRmResourceGroup -Location $ResourceLocation -Name $ResourceName\n\n';
+            throwIfNotEqual(expectedScripts.length, actualSupportedCommands.length);
+
+            let expectedScriptIndex: number = 0;
+            for (let cmdActionPair of actualSupportedCommands) {
+                throwIfNotEqual(expectedScripts[expectedScriptIndex++], scriptGenerator.getScript(cmdActionPair));
+            }
+
+            logSuccess(arguments);
+        }
+
+        function scriptResourceIDOnlyWithResourceGroupName() {
+            let resourceDefinition = {} as IResourceDefinition;
+            resourceDefinition.actions = ["GET", "PUT", "DELETE"];
+            resourceDefinition.apiVersion = "2014-04-01";
+            resourceDefinition.children = ["exportTemplate", "moveResources", "providers", "validateMoveResources"];
+
+            let actions = [] as IAction[];
+            actions[0] = { httpMethod: "DELETE", name: "Delete", url: "https://management.azure.com/subscriptions/6e6e25b…-43f4-bdde-1864842e524b/resourceGroups/cloudsvcrg", query: undefined, requestBody: undefined };
+            actions[1] = { httpMethod: "POST", name: "exportTemplate", url: "https://management.azure.com/subscriptions/6e6e25b…842e524b/resourceGroups/cloudsvcrg/exportTemplate", query: undefined, requestBody: '{"options": "IncludeParameterDefaultValue, IncludeComments", "resources": ["* "]}' };
+            actions[2] = { httpMethod: "POST", name: "moveResources", url: "https://management.azure.com/subscriptions/6e6e25b…842e524b/resourceGroups/cloudsvcrg/moveResources", query: undefined, requestBody: '{"targetResourceGroup": "(string)","resources": ["(string)"]}' };
+            actions[3] = { httpMethod: "POST", name: "validateMoveResources", url: "https://management.azure.com/subscriptions/6e6e25b…842e524b/resourceGroups/cloudsvcrg/validateMoveResources", query: undefined, requestBody: '{"targetResourceGroup": "(string)","resources": ["(string)"]}' };
+
+            let value = {} as ISelectHandlerReturn;
+            value.httpMethod = "GET";
+            value.url = "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloudsvcrg";
+            value.resourceDefinition = resourceDefinition;
+            let resolver = new PSCmdletParameterResolver(new ARMUrlParser(value,actions));
+            let scriptGenerator = new PsScriptGenerator(resolver);
+            let actualSupportedCommands: Array<RMCommandInfo> = resolver.getSupportedCommands();
+
+            let expectedScripts = [] as Array<string>;
+            expectedScripts[0] = "# GET cloudsvcrg\nGet-AzureRmResource -ResourceId /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloudsvcrg -ApiVersion 2014-04-01\n\n";
+            expectedScripts[1] = '# SET cloudsvcrg\n$PropertiesObject = @{\n\t#Property = value;\n}\nSet-AzureRmResource -PropertyObject $PropertiesObject -ResourceId /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloudsvcrg -ApiVersion 2014-04-01 -Force\n\n';
+            expectedScripts[2] = '# DELETE cloudsvcrg\nRemove-AzureRmResource -ResourceId /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloudsvcrg -ApiVersion 2014-04-01 -Force\n\n';
+            expectedScripts[3] = '# Action exportTemplate\n$ParametersObject = @{\n\toptions = "IncludeParameterDefaultValue, IncludeComments"\n\tresources = (\n\t\t"* "\n\t)\n}\n\nInvoke-AzureRmResourceAction -ResourceId /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloudsvcrg -Action exportTemplate -Parameters $ParametersObject -ApiVersion 2014-04-01 -Force\n\n';
+            expectedScripts[4] = '# Action moveResources\n$ParametersObject = @{\n\ttargetResourceGroup = "(string)"\n\tresources = (\n\t\t"(string)"\n\t)\n}\n\nInvoke-AzureRmResourceAction -ResourceId /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloudsvcrg -Action moveResources -Parameters $ParametersObject -ApiVersion 2014-04-01 -Force\n\n';
+            expectedScripts[5] = '# Action validateMoveResources\n$ParametersObject = @{\n\ttargetResourceGroup = "(string)"\n\tresources = (\n\t\t"(string)"\n\t)\n}\n\nInvoke-AzureRmResourceAction -ResourceId /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloudsvcrg -Action validateMoveResources -Parameters $ParametersObject -ApiVersion 2014-04-01 -Force\n\n';
+            
+            throwIfNotEqual(expectedScripts.length, actualSupportedCommands.length);
+
+            let expectedScriptIndex: number = 0;
+            for (let cmdActionPair of actualSupportedCommands) {
+                throwIfNotEqual(expectedScripts[expectedScriptIndex++], scriptGenerator.getScript(cmdActionPair));
+            }
+
+            logSuccess(arguments);
+        }
+
+        function scriptResGrpNameResType() {
+            let resourceDefinition = {} as IResourceDefinition;
+            resourceDefinition.actions = ["GET", "CREATE"];
+            resourceDefinition.apiVersion = "2016-04-01";
+            resourceDefinition.children = "{name}";
+
+            let value = {} as ISelectHandlerReturn;
+            value.httpMethod = "GET";
+            value.url = "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloudsvcrg/providers/Microsoft.ClassicCompute/domainNames";
+            value.resourceDefinition = resourceDefinition;
+            let resolver = new PSCmdletParameterResolver(new ARMUrlParser(value,[]));
+            let scriptGenerator = new PsScriptGenerator(resolver);
+            let actualSupportedCommands: Array<RMCommandInfo> = resolver.getSupportedCommands();
+
+            let expectedScripts = [] as Array<string>;
+            expectedScripts[0] = "# GET domainNames\nGet-AzureRmResource -ResourceGroupName cloudsvcrg -ResourceType Microsoft.ClassicCompute/domainNames -IsCollection -ApiVersion 2016-04-01\n\n";
+            expectedScripts[1] = '# CREATE domainNames\n$ResourceLocation = "West US"\n$ResourceName = "NewdomainName"\n$PropertiesObject = @{\n\t#Property = value;\n}\nNew-AzureRmResource -ResourceName $ResourceName -Location $ResourceLocation -PropertyObject $PropertiesObject -ResourceGroupName cloudsvcrg -ResourceType Microsoft.ClassicCompute/domainNames -ApiVersion 2016-04-01 -Force\n\n';
+            throwIfNotEqual(expectedScripts.length, actualSupportedCommands.length);
+
+            let expectedScriptIndex: number = 0;
+            for (let cmdActionPair of actualSupportedCommands) {
+                throwIfNotEqual(expectedScripts[expectedScriptIndex++], scriptGenerator.getScript(cmdActionPair));
+            }
+
+            logSuccess(arguments);
+        }
+
+        function scriptResGrpNameResTypeResName() {
+            let resourceDefinition = {} as IResourceDefinition;
+            resourceDefinition.actions = ["GET", "PUT", "DELETE"];
+            resourceDefinition.apiVersion = "2016-04-01";
+            resourceDefinition.children = ["slots"];
+
+            let actions = [] as IAction[];
+            actions[0] = { httpMethod: "DELETE", name: "Delete", url: "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloudsvcrg/providers/Microsoft.ClassicCompute/domainNames/x123cloudsvc", query: undefined, requestBody: undefined };
+
+            let value = {} as ISelectHandlerReturn;
+            value.httpMethod = "GET";
+            value.url = "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloudsvcrg/providers/Microsoft.ClassicCompute/domainNames/x123cloudsvc";
+            value.resourceDefinition = resourceDefinition;
+            let resolver = new PSCmdletParameterResolver(new ARMUrlParser(value, actions));
+            let scriptGenerator = new PsScriptGenerator(resolver);
+            let actualSupportedCommands: Array<RMCommandInfo> = resolver.getSupportedCommands();
+
+            let expectedScripts = [] as Array<string>;
+            expectedScripts[0] = '# GET x123cloudsvc\nGet-AzureRmResource -ResourceGroupName cloudsvcrg -ResourceType Microsoft.ClassicCompute/domainNames -ResourceName "x123cloudsvc" -ApiVersion 2016-04-01\n\n';
+            expectedScripts[1] = '# SET x123cloudsvc\n$PropertiesObject = @{\n\t#Property = value;\n}\nSet-AzureRmResource -PropertyObject $PropertiesObject -ResourceGroupName cloudsvcrg -ResourceType Microsoft.ClassicCompute/domainNames -ResourceName "x123cloudsvc" -ApiVersion 2016-04-01 -Force\n\n';
+            expectedScripts[2] = '# DELETE x123cloudsvc\nRemove-AzureRmResource -ResourceGroupName cloudsvcrg -ResourceType Microsoft.ClassicCompute/domainNames -ResourceName "x123cloudsvc" -ApiVersion 2016-04-01 -Force\n\n';
+
+            throwIfNotEqual(expectedScripts.length, actualSupportedCommands.length);
+
+            let expectedScriptIndex: number = 0;
+            for (let cmdActionPair of actualSupportedCommands) {
+                throwIfNotEqual(expectedScripts[expectedScriptIndex++], scriptGenerator.getScript(cmdActionPair));
+            }
+            logSuccess(arguments);
+        }
+
+        function scriptResGrpNameResTypeResNameSubType1() {
+            let resourceDefinition = {} as IResourceDefinition;
+            resourceDefinition.actions = ["GET", "CREATE"];
+            resourceDefinition.apiVersion = "2016-04-01";
+            resourceDefinition.children = "{name}";
+
+            let value = {} as ISelectHandlerReturn;
+            value.httpMethod = "GET";
+            value.url = "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloudsvcrg/providers/Microsoft.ClassicCompute/domainNames/x123cloudsvc/slots";
+            value.resourceDefinition = resourceDefinition;
+            let resolver = new PSCmdletParameterResolver(new ARMUrlParser(value,[]));
+            let scriptGenerator = new PsScriptGenerator(resolver);
+            let actualSupportedCommands: Array<RMCommandInfo> = resolver.getSupportedCommands();
+
+            let expectedScripts = [] as Array<string>;
+            expectedScripts[0] = '# GET slots\nGet-AzureRmResource -ResourceGroupName cloudsvcrg -ResourceType Microsoft.ClassicCompute/domainNames/slots -ResourceName "x123cloudsvc" -ApiVersion 2016-04-01\n\n';
+            expectedScripts[1] = '# CREATE slots\n$ResourceLocation = "West US"\n$ResourceName = "Newslot"\n$PropertiesObject = @{\n\t#Property = value;\n}\nNew-AzureRmResource -Location $ResourceLocation -PropertyObject $PropertiesObject -ResourceGroupName cloudsvcrg -ResourceType Microsoft.ClassicCompute/domainNames/slots -ResourceName "x123cloudsvc/$ResourceName" -ApiVersion 2016-04-01 -Force\n\n';
+
+            throwIfNotEqual(expectedScripts.length, actualSupportedCommands.length);
+
+            let expectedScriptIndex: number = 0;
+            for (let cmdActionPair of actualSupportedCommands) {
+                throwIfNotEqual(expectedScripts[expectedScriptIndex++], scriptGenerator.getScript(cmdActionPair));
+            }
+
+            logSuccess(arguments);
+        }
+
+        function scriptResGrpNameResTypeResNameSubType1SubName1() {
+            let resourceDefinition = {} as IResourceDefinition;
+            resourceDefinition.actions = ["GET", "DELETE", "PUT"];
+            resourceDefinition.apiVersion = "2016-04-01";
+            resourceDefinition.children = ["roles"];
+
+            let actions = [] as IAction[];
+            actions[0] = { httpMethod: "DELETE", name: "Delete", url: "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloudsvcrg/providers/Microsoft.ClassicCompute/domainNames/x123cloudsvc/slots/Production", query: undefined, requestBody: undefined };
+
+            let value = {} as ISelectHandlerReturn;
+            value.httpMethod = "GET";
+            value.url = "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloudsvcrg/providers/Microsoft.ClassicCompute/domainNames/x123cloudsvc/slots/Production";
+            value.resourceDefinition = resourceDefinition;
+            let resolver = new PSCmdletParameterResolver(new ARMUrlParser(value, actions));
+            let scriptGenerator = new PsScriptGenerator(resolver);
+            let actualSupportedCommands: Array<RMCommandInfo> = resolver.getSupportedCommands();
+
+            let expectedScripts = [] as Array<string>;
+            expectedScripts[0] = '# GET Production\nGet-AzureRmResource -ResourceGroupName cloudsvcrg -ResourceType Microsoft.ClassicCompute/domainNames/slots -ResourceName "x123cloudsvc/Production" -ApiVersion 2016-04-01\n\n';
+            expectedScripts[1] = '# SET Production\n$PropertiesObject = @{\n\t#Property = value;\n}\nSet-AzureRmResource -PropertyObject $PropertiesObject -ResourceGroupName cloudsvcrg -ResourceType Microsoft.ClassicCompute/domainNames/slots -ResourceName "x123cloudsvc/Production" -ApiVersion 2016-04-01 -Force\n\n';
+            expectedScripts[2] = '# DELETE Production\nRemove-AzureRmResource -ResourceGroupName cloudsvcrg -ResourceType Microsoft.ClassicCompute/domainNames/slots -ResourceName "x123cloudsvc/Production" -ApiVersion 2016-04-01 -Force\n\n';
+            throwIfNotEqual(expectedScripts.length, actualSupportedCommands.length);
+
+            let expectedScriptIndex: number = 0;
+            for (let cmdActionPair of actualSupportedCommands) {
+                throwIfNotEqual(expectedScripts[expectedScriptIndex++], scriptGenerator.getScript(cmdActionPair));
+            }
+
+            logSuccess(arguments);
+        }
+
+        function scriptResGrpNameResTypeResNameSubType1SubName1SubType2() {
+            let resourceDefinition = {} as IResourceDefinition;
+            resourceDefinition.actions = ["GET", "CREATE"];
+            resourceDefinition.apiVersion = "2016-04-01";
+            resourceDefinition.children = "{name}";
+
+            let value = {} as ISelectHandlerReturn;
+            value.httpMethod = "GET";
+            value.url = "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloudsvcrg/providers/Microsoft.ClassicCompute/domainNames/x123cloudsvc/slots/Production/roles";
+            value.resourceDefinition = resourceDefinition;
+            let resolver = new PSCmdletParameterResolver(new ARMUrlParser(value, []));
+            let scriptGenerator = new PsScriptGenerator(resolver);
+            let actualSupportedCommands: Array<RMCommandInfo> = resolver.getSupportedCommands();
+
+            let expectedScripts = [] as Array<string>;
+            expectedScripts[0] = '# GET roles\nGet-AzureRmResource -ResourceGroupName cloudsvcrg -ResourceType Microsoft.ClassicCompute/domainNames/slots/roles -ResourceName "x123cloudsvc/Production" -ApiVersion 2016-04-01\n\n';
+            expectedScripts[1] = '# CREATE roles\n$ResourceLocation = "West US"\n$ResourceName = "Newrole"\n$PropertiesObject = @{\n\t#Property = value;\n}\nNew-AzureRmResource -Location $ResourceLocation -PropertyObject $PropertiesObject -ResourceGroupName cloudsvcrg -ResourceType Microsoft.ClassicCompute/domainNames/slots/roles -ResourceName "x123cloudsvc/Production/$ResourceName" -ApiVersion 2016-04-01 -Force\n\n';
+            throwIfNotEqual(expectedScripts.length, actualSupportedCommands.length);
+
+            let expectedScriptIndex: number = 0;
+            for (let cmdActionPair of actualSupportedCommands) {
+                throwIfNotEqual(expectedScripts[expectedScriptIndex++], scriptGenerator.getScript(cmdActionPair));
+            }
+
+            logSuccess(arguments);
+        }
+
+        function scriptResGrpNameResTypeResNameSubType1SubName1SubType2SubName2() {
+            let resourceDefinition = {} as IResourceDefinition;
+            resourceDefinition.actions = ["GET", "DELETE", "PUT"];
+            resourceDefinition.apiVersion = "2016-04-01";
+            resourceDefinition.children = ["metricDefinitions", "metrics"];
+
+            let actions = [] as IAction[];
+            actions[0] = { httpMethod: "DELETE", name: "Delete", url: "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloudsvcrg/providers/Microsoft.ClassicCompute/domainNames/x123cloudsvc/slots/Production/roles/WorkerRole1", query: undefined, requestBody: undefined };
+
+            let value = {} as ISelectHandlerReturn;
+            value.httpMethod = "GET";
+            value.url = "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloudsvcrg/providers/Microsoft.ClassicCompute/domainNames/x123cloudsvc/slots/Production/roles/WorkerRole1";
+            value.resourceDefinition = resourceDefinition;
+            let resolver = new PSCmdletParameterResolver(new ARMUrlParser(value, actions));
+            let scriptGenerator = new PsScriptGenerator(resolver);
+            let actualSupportedCommands: Array<RMCommandInfo> = resolver.getSupportedCommands();
+
+            let expectedScripts = [] as Array<string>;
+            expectedScripts[0] = '# GET WorkerRole1\nGet-AzureRmResource -ResourceGroupName cloudsvcrg -ResourceType Microsoft.ClassicCompute/domainNames/slots/roles -ResourceName "x123cloudsvc/Production/WorkerRole1" -ApiVersion 2016-04-01\n\n';
+            expectedScripts[1] = '# SET WorkerRole1\n$PropertiesObject = @{\n\t#Property = value;\n}\nSet-AzureRmResource -PropertyObject $PropertiesObject -ResourceGroupName cloudsvcrg -ResourceType Microsoft.ClassicCompute/domainNames/slots/roles -ResourceName "x123cloudsvc/Production/WorkerRole1" -ApiVersion 2016-04-01 -Force\n\n';
+            expectedScripts[2] = '# DELETE WorkerRole1\nRemove-AzureRmResource -ResourceGroupName cloudsvcrg -ResourceType Microsoft.ClassicCompute/domainNames/slots/roles -ResourceName "x123cloudsvc/Production/WorkerRole1" -ApiVersion 2016-04-01 -Force\n\n';
+            throwIfNotEqual(expectedScripts.length, actualSupportedCommands.length);
+
+            let expectedScriptIndex: number = 0;
+            for (let cmdActionPair of actualSupportedCommands) {
+                throwIfNotEqual(expectedScripts[expectedScriptIndex++], scriptGenerator.getScript(cmdActionPair));
+            }
+
+            logSuccess(arguments);
+        }
+
+        function scriptResGrpNameResTypeResNameSubType1SubName1SubType2SubName2SubType3() {
+            let resourceDefinition = {} as IResourceDefinition;
+            resourceDefinition.actions = ["GET", "CREATE"];
+            resourceDefinition.apiVersion = "2014-04-01";
+            resourceDefinition.children = "{name}";
+
+            let value = {} as ISelectHandlerReturn;
+            value.httpMethod = "GET";
+            value.url = "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloudsvcrg/providers/Microsoft.ClassicCompute/domainNames/x123cloudsvc/slots/Production/roles/WorkerRole1/metricDefinitions";
+            value.resourceDefinition = resourceDefinition;
+            let resolver = new PSCmdletParameterResolver(new ARMUrlParser(value, []));
+            let scriptGenerator = new PsScriptGenerator(resolver);
+            let actualSupportedCommands: Array<RMCommandInfo> = resolver.getSupportedCommands();
+
+            let expectedScripts = [] as Array<string>;
+            expectedScripts[0] = '# GET metricDefinitions\nGet-AzureRmResource -ResourceGroupName cloudsvcrg -ResourceType Microsoft.ClassicCompute/domainNames/slots/roles/metricDefinitions -ResourceName "x123cloudsvc/Production/WorkerRole1" -ApiVersion 2014-04-01\n\n';
+            expectedScripts[1] = '# CREATE metricDefinitions\n$ResourceLocation = "West US"\n$ResourceName = "NewmetricDefinition"\n$PropertiesObject = @{\n\t#Property = value;\n}\nNew-AzureRmResource -Location $ResourceLocation -PropertyObject $PropertiesObject -ResourceGroupName cloudsvcrg -ResourceType Microsoft.ClassicCompute/domainNames/slots/roles/metricDefinitions -ResourceName "x123cloudsvc/Production/WorkerRole1/$ResourceName" -ApiVersion 2014-04-01 -Force\n\n';
+            throwIfNotEqual(expectedScripts.length, actualSupportedCommands.length);
+
+            let expectedScriptIndex: number = 0;
+            for (let cmdActionPair of actualSupportedCommands) {
+                throwIfNotEqual(expectedScripts[expectedScriptIndex++], scriptGenerator.getScript(cmdActionPair));
+            }
+
+            logSuccess(arguments);
+        }
+
+        function scriptResGrpNameResTypeResNameSubType1SubName1SubType2SubName2SubType3SubName3() {
+            let resourceDefinition = {} as IResourceDefinition;
+            resourceDefinition.actions = ["PUT", "GET", "DELETE"];
+            resourceDefinition.apiVersion = "2014-04-01";
+            resourceDefinition.children = "{name}";
+
+            let actions = [] as IAction[];
+            actions[0] = { httpMethod: "DELETE", name: "Delete", url: "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloudsvcrg/providers/Microsoft.ClassicCompute/domainNames/x123cloudsvc/slots/Production/roles/WorkerRole1/metricDefinitions/Percentage CPU", query: undefined, requestBody: undefined };
+
+            let value = {} as ISelectHandlerReturn;
+            value.httpMethod = "GET";
+            value.url = "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloudsvcrg/providers/Microsoft.ClassicCompute/domainNames/x123cloudsvc/slots/Production/roles/WorkerRole1/metricDefinitions/Percentage CPU";
+            value.resourceDefinition = resourceDefinition;
+            let resolver = new PSCmdletParameterResolver(new ARMUrlParser(value, actions));
+            let scriptGenerator = new PsScriptGenerator(resolver);
+            let actualSupportedCommands: Array<RMCommandInfo> = resolver.getSupportedCommands();
+
+            let expectedScripts = [] as Array<string>;
+            expectedScripts[0] = '# GET Percentage CPU\nGet-AzureRmResource -ResourceGroupName cloudsvcrg -ResourceType Microsoft.ClassicCompute/domainNames/slots/roles/metricDefinitions -ResourceName "x123cloudsvc/Production/WorkerRole1/Percentage CPU" -ApiVersion 2014-04-01\n\n';
+            expectedScripts[1] = '# SET Percentage CPU\n$PropertiesObject = @{\n\t#Property = value;\n}\nSet-AzureRmResource -PropertyObject $PropertiesObject -ResourceGroupName cloudsvcrg -ResourceType Microsoft.ClassicCompute/domainNames/slots/roles/metricDefinitions -ResourceName "x123cloudsvc/Production/WorkerRole1/Percentage CPU" -ApiVersion 2014-04-01 -Force\n\n';
+            expectedScripts[2] = '# DELETE Percentage CPU\nRemove-AzureRmResource -ResourceGroupName cloudsvcrg -ResourceType Microsoft.ClassicCompute/domainNames/slots/roles/metricDefinitions -ResourceName "x123cloudsvc/Production/WorkerRole1/Percentage CPU" -ApiVersion 2014-04-01 -Force\n\n';
+            throwIfNotEqual(expectedScripts.length, actualSupportedCommands.length);
+
+            let expectedScriptIndex: number = 0;
+            for (let cmdActionPair of actualSupportedCommands) {
+                throwIfNotEqual(expectedScripts[expectedScriptIndex++], scriptGenerator.getScript(cmdActionPair));
+            }
+
+            logSuccess(arguments);
+        }
+
+        function scriptResourceUrlWithList() {
+            let resourceDefinition = {} as IResourceDefinition;
+            resourceDefinition.actions = ["PUT", "GETPOST"];
+            resourceDefinition.apiVersion = "2016-03-01";
+            resourceDefinition.children = "{name}";
+
+            let value = {} as ISelectHandlerReturn;
+            value.httpMethod = "POST";
+            value.url = "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgrp1/providers/Microsoft.Web/sites/WebApp120170517014339/config/appsettings/list";
+            value.resourceDefinition = resourceDefinition;
+            let resolver = new PSCmdletParameterResolver(new ARMUrlParser(value,[]));
+            let scriptGenerator = new PsScriptGenerator(resolver);
+            let actualSupportedCommands: Array<RMCommandInfo> = resolver.getSupportedCommands();
+
+            let expectedScripts = [] as Array<string>;
+            expectedScripts[0] = '# LIST appsettings\n$resource = Invoke-AzureRmResourceAction -ResourceGroupName rgrp1 -ResourceType Microsoft.Web/sites/config -ResourceName "WebApp120170517014339/appsettings" -Action list -ApiVersion 2016-03-01 -Force\n$resource.Properties\n\n';
+            expectedScripts[1] = '# SET list\n$PropertiesObject = @{\n\t#Property = value;\n}\nNew-AzureRmResource -PropertyObject $PropertiesObject -ResourceGroupName rgrp1 -ResourceType Microsoft.Web/sites/config -ResourceName "WebApp120170517014339/appsettings" -ApiVersion 2016-03-01 -Force\n\n';
+
+            throwIfNotEqual(expectedScripts.length, actualSupportedCommands.length);
+
+            let expectedScriptIndex: number = 0;
+            for (let cmdActionPair of actualSupportedCommands) {
+                throwIfNotEqual(expectedScripts[expectedScriptIndex++], scriptGenerator.getScript(cmdActionPair));
+            }
+
+            logSuccess(arguments);
+        }
+    }
+
+    namespace PSCmdletParameterResolverTests {
+        getParametersForSubscriptions();
+        getParametersForSubscriptionsSubId();
+        getParametersForSubscriptionsSubIdResGroup();
+        getParametersForResourceIDOnlyWithResourceGroupName();
+        getParametersForResGrpNameResType();
+        getParametersForResGrpNameResTypeResName();
+        getParametersForResGrpNameResTypeResNameSubType1();
+        getParametersForResGrpNameResTypeResNameSubType1SubName1();
+        getParametersForResGrpNameResTypeResNameSubType1SubName1SubType2();
+        getParametersForResGrpNameResTypeResNameSubType1SubName1SubType2SubName2();
+        getParametersForResGrpNameResTypeResNameSubType1SubName1SubType2SubName2SubType3();
+        getParametersForResGrpNameResTypeResNameSubType1SubName1SubType2SubName2SubType3SubName3();
+        getParametersForResourceUrlWithList();
+
+        function getParametersForSubscriptions() {
+            let resourceDefinition = {} as IResourceDefinition;
+            resourceDefinition.actions = ["GET"];
+            resourceDefinition.apiVersion = "2014-04-01";
+            resourceDefinition.children = "{name}";
+
+            let value = {} as ISelectHandlerReturn;
+            value.httpMethod = "GET";
+            value.url = "https://management.azure.com/subscriptions";
+            value.resourceDefinition = resourceDefinition;
+            
+            let resolver = new PSCmdletParameterResolver(new ARMUrlParser(value, []));
+            let actualSupportedCommands: Array<RMCommandInfo> = resolver.getSupportedCommands();
+            let expectedSupportedCommands: Array<RMCommandInfo> = [{ cmd: "Get-AzureRmResource", isAction: false, isSetAction: false }];
+
+            throwIfArrayNotEqual(expectedSupportedCommands, actualSupportedCommands);
+
+            let expectedcCmdletParameters = [] as Array<CmdletParameters>;
+            let cmdletParameters = {} as CmdletParameters;
+            let cmdletResourceInfo = {} as ResourceIdentifier;
+            cmdletResourceInfo.resourceIdentifierType = ResourceIdentifierType.WithIDOnly;
+            cmdletResourceInfo.resourceId = "/subscriptions";
+            cmdletParameters.resourceIdentifier = cmdletResourceInfo;
+            cmdletParameters.apiVersion = "2014-04-01";
+            cmdletParameters.isCollection  = false;
+
+            expectedcCmdletParameters.push(cmdletParameters);
+
+            let cmdIndex = 0;
+            for (let actualCmdType of actualSupportedCommands) {
+                throwIfObjectNotEqual(expectedcCmdletParameters[cmdIndex], resolver.getParameters());
+            }
+
+            logSuccess(arguments);
+        }
+
+        function getParametersForSubscriptionsSubId() {
+            let resourceDefinition = {} as IResourceDefinition;
+            resourceDefinition.actions = ["GET"];
+            resourceDefinition.apiVersion = "2014-04-01";
+            resourceDefinition.children = "{name}";
+
+            let value = {} as ISelectHandlerReturn;
+            value.httpMethod = "GET";
+            value.url = "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000";
+            value.resourceDefinition = resourceDefinition;
+            let resolver = new PSCmdletParameterResolver(new ARMUrlParser(value,[]));
+            let actualSupportedCommands: Array<RMCommandInfo> = resolver.getSupportedCommands();
+            let expectedSupportedCommands: Array<RMCommandInfo> = [{ cmd: "Get-AzureRmResource", isAction: false, isSetAction: false }];
+
+            throwIfArrayNotEqual(expectedSupportedCommands, actualSupportedCommands);
+
+            let expectedCmdletParameters = [] as Array<CmdletParameters>;
+            let cmdletParameters = {} as CmdletParameters;
+            let cmdletResourceInfo = {} as ResourceIdentifier;
+            cmdletResourceInfo.resourceIdentifierType = ResourceIdentifierType.WithIDOnly;
+            cmdletResourceInfo.resourceId = "/subscriptions/00000000-0000-0000-0000-000000000000";
+            cmdletParameters.resourceIdentifier = cmdletResourceInfo;
+            cmdletParameters.apiVersion = "2014-04-01";
+            cmdletParameters.isCollection = false;
+
+            expectedCmdletParameters.push(cmdletParameters);
+
+            let cmdIndex = 0;
+            for (let actualCmdType of actualSupportedCommands) {
+                throwIfObjectNotEqual(expectedCmdletParameters[cmdIndex], resolver.getParameters());
+            }
+
+            logSuccess(arguments);
+        }
+
+        function getParametersForSubscriptionsSubIdResGroup() {
+            let resourceDefinition = {} as IResourceDefinition;
+            resourceDefinition.actions = ["GET", "CREATE"];
+            resourceDefinition.apiVersion = "2014-04-01";
+            resourceDefinition.children = "{name}";
+
+            let value = {} as ISelectHandlerReturn;
+            value.httpMethod = "GET";
+            value.url = "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups";
+            value.resourceDefinition = resourceDefinition;
+            let resolver = new PSCmdletParameterResolver(new ARMUrlParser(value,[]));
+            let actualSupportedCommands: Array<RMCommandInfo> = resolver.getSupportedCommands();
+            let expectedSupportedCommands: Array<RMCommandInfo> = [{ cmd: "Get-AzureRmResource", isAction: false, isSetAction: false }, { cmd: "New-AzureRmResourceGroup", isAction: false, isSetAction: false }];
+
+            throwIfArrayNotEqual(expectedSupportedCommands, actualSupportedCommands);
+
+            let cmdletParameters = {} as CmdletParameters;
+            let cmdletResourceInfo = {} as ResourceIdentifier;
+            cmdletResourceInfo.resourceIdentifierType = ResourceIdentifierType.WithIDOnly;
+            cmdletResourceInfo.resourceId = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups";
+            cmdletParameters.resourceIdentifier = cmdletResourceInfo;
+            cmdletParameters.apiVersion = "2014-04-01";
+            cmdletParameters.isCollection = false;
+
+            throwIfObjectNotEqual(cmdletParameters, resolver.getParameters());
+
+            logSuccess(arguments);
+        }
+
+        function getParametersForResourceIDOnlyWithResourceGroupName() {
+            let resourceDefinition = {} as IResourceDefinition;
+            resourceDefinition.actions = ["GET", "PUT", "DELETE"];
+            resourceDefinition.apiVersion = "2014-04-01";
+            resourceDefinition.children = ["exportTemplate", "moveResources", "providers", "validateMoveResources"];
+
+            let actions = [] as IAction[];
+            actions[0] = { httpMethod: "DELETE", name: "Delete", url: "https://management.azure.com/subscriptions/6e6e25b…-43f4-bdde-1864842e524b/resourceGroups/cloudsvcrg", query: undefined, requestBody: undefined };
+            actions[1] = { httpMethod: "POST", name: "exportTemplate", url: "https://management.azure.com/subscriptions/6e6e25b…842e524b/resourceGroups/cloudsvcrg/exportTemplate", query: undefined, requestBody: "{'options': 'IncludeParameterDefaultValue, IncludeComments', 'resources': ['* ']}" };
+            actions[2] = { httpMethod: "POST", name: "moveResources", url: "https://management.azure.com/subscriptions/6e6e25b…842e524b/resourceGroups/cloudsvcrg/moveResources", query: undefined, requestBody: "{'targetResourceGroup': '(string)','resources': ['(string)']}" };
+            actions[3] = { httpMethod: "POST", name: "validateMoveResources", url: "https://management.azure.com/subscriptions/6e6e25b…842e524b/resourceGroups/cloudsvcrg/validateMoveResources", query: undefined, requestBody: "{'targetResourceGroup': '(string)','resources': ['(string)']}" };
+
+            let value = {} as ISelectHandlerReturn;
+            value.httpMethod = "GET";
+            value.url = "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloudsvcrg";
+            value.resourceDefinition = resourceDefinition;
+            let resolver = new PSCmdletParameterResolver(new ARMUrlParser(value, actions));
+            let actualSupportedCommands: Array<RMCommandInfo> = resolver.getSupportedCommands();
+            let expectedSupportedCommands: Array<RMCommandInfo> = [
+                { cmd: "Get-AzureRmResource", isAction: false, isSetAction: false },
+                { cmd: "Set-AzureRmResource", isAction: false, isSetAction: true },
+                { cmd: "Remove-AzureRmResource", isAction: true, isSetAction: false },
+                { cmd: "Invoke-AzureRmResourceAction", isAction: true, isSetAction: false },
+                { cmd: "Invoke-AzureRmResourceAction", isAction: true, isSetAction: false },
+                { cmd: "Invoke-AzureRmResourceAction", isAction: true, isSetAction: false }];
+
+            throwIfArrayNotEqual(expectedSupportedCommands, actualSupportedCommands);
+
+            let cmdletParameters = {} as CmdletParameters;
+            let cmdletResourceInfo = {} as ResourceIdentifier;
+            cmdletResourceInfo.resourceIdentifierType = ResourceIdentifierType.WithIDOnly;
+            cmdletResourceInfo.resourceId = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloudsvcrg";
+            cmdletParameters.resourceIdentifier = cmdletResourceInfo;
+            cmdletParameters.apiVersion = "2014-04-01";
+            cmdletParameters.isCollection = false;
+            throwIfObjectNotEqual(cmdletParameters, resolver.getParameters());
+
+            logSuccess(arguments);
+        }
+
+        function getParametersForResGrpNameResType() {
+            let resourceDefinition = {} as IResourceDefinition;
+            resourceDefinition.actions = ["GET", "CREATE"];
+            resourceDefinition.apiVersion = "2016-04-01";
+            resourceDefinition.children = "{name}";
+
+            let value = {} as ISelectHandlerReturn;
+            value.httpMethod = "GET";
+            value.url = "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloudsvcrg/providers/Microsoft.ClassicCompute/domainNames";
+            value.resourceDefinition = resourceDefinition;
+            let resolver = new PSCmdletParameterResolver(new ARMUrlParser(value,[]));
+            let actualSupportedCommands: Array<RMCommandInfo> = resolver.getSupportedCommands();
+            let expectedSupportedCommands: Array<RMCommandInfo> = [{ cmd: "Get-AzureRmResource", isAction: false, isSetAction: false }, { cmd: "New-AzureRmResource", isAction: false, isSetAction: false }];
+
+            throwIfArrayNotEqual(expectedSupportedCommands, actualSupportedCommands);
+
+            let cmdletParameters = {} as CmdletParameters;
+            let cmdletResourceInfo = {} as ResourceIdentifier;
+            cmdletResourceInfo.resourceIdentifierType = ResourceIdentifierType.WithGroupType;
+            cmdletResourceInfo.resourceGroup = "cloudsvcrg";
+            cmdletResourceInfo.resourceType = "Microsoft.ClassicCompute/domainNames";
+            cmdletParameters.resourceIdentifier = cmdletResourceInfo;
+            cmdletParameters.apiVersion = "2016-04-01";
+            cmdletParameters.isCollection = true;
+            throwIfObjectNotEqual(cmdletParameters, resolver.getParameters());
+
+            logSuccess(arguments);
+        }
+
+        function getParametersForResGrpNameResTypeResName() {
+            let resourceDefinition = {} as IResourceDefinition;
+            resourceDefinition.actions = ["GET", "PUT", "DELETE"];
+            resourceDefinition.apiVersion = "2016-04-01";
+            resourceDefinition.children = ["slots"];
+
+            let actions = [] as IAction[];
+            actions[0] = { httpMethod: "DELETE", name: "Delete", url: "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloudsvcrg/providers/Microsoft.ClassicCompute/domainNames/x123cloudsvc", query: undefined, requestBody: undefined };
+
+            let value = {} as ISelectHandlerReturn;
+            value.httpMethod = "GET";
+            value.url = "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloudsvcrg/providers/Microsoft.ClassicCompute/domainNames/x123cloudsvc";
+            value.resourceDefinition = resourceDefinition;
+            let resolver = new PSCmdletParameterResolver(new ARMUrlParser(value, actions));
+            let actualSupportedCommands: Array<RMCommandInfo> = resolver.getSupportedCommands();
+            let expectedSupportedCommands: Array<RMCommandInfo> = [{ cmd: "Get-AzureRmResource", isAction: false, isSetAction: false }, { cmd: "Set-AzureRmResource", isAction: false, isSetAction: true },
+                { cmd: "Remove-AzureRmResource", isAction: true, isSetAction: false }];
+
+            throwIfArrayNotEqual(expectedSupportedCommands, actualSupportedCommands);
+
+            let cmdletParameters = {} as CmdletParameters;
+            let cmdletResourceInfo = {} as ResourceIdentifier;
+            cmdletResourceInfo.resourceIdentifierType = ResourceIdentifierType.WithGroupTypeName;
+            cmdletResourceInfo.resourceGroup = "cloudsvcrg";
+            cmdletResourceInfo.resourceName = "x123cloudsvc";
+            cmdletResourceInfo.resourceType = "Microsoft.ClassicCompute/domainNames";
+            cmdletParameters.resourceIdentifier = cmdletResourceInfo;
+            cmdletParameters.apiVersion = "2016-04-01";
+            cmdletParameters.isCollection = false;
+            throwIfObjectNotEqual(cmdletParameters, resolver.getParameters());
+
+            logSuccess(arguments);
+        }
+
+        function getParametersForResGrpNameResTypeResNameSubType1() {
+            let resourceDefinition = {} as IResourceDefinition;
+            resourceDefinition.actions = ["GET", "CREATE"];
+            resourceDefinition.apiVersion = "2014-04-01";
+            resourceDefinition.children = "{name}";
+
+            let value = {} as ISelectHandlerReturn;
+            value.httpMethod = "GET";
+            value.url = "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloudsvcrg/providers/Microsoft.ClassicCompute/domainNames/x123cloudsvc/slots";
+            value.resourceDefinition = resourceDefinition;
+            let resolver = new PSCmdletParameterResolver(new ARMUrlParser(value,[]));
+            let actualSupportedCommands: Array<RMCommandInfo> = resolver.getSupportedCommands();
+            let expectedSupportedCommands: Array<RMCommandInfo> = [{ cmd: "Get-AzureRmResource", isAction: false, isSetAction: false }, { cmd: "New-AzureRmResource", isAction: false, isSetAction: false }];
+
+            throwIfArrayNotEqual(expectedSupportedCommands, actualSupportedCommands);
+
+            let cmdletParameters = {} as CmdletParameters;
+            let cmdletResourceInfo = {} as ResourceIdentifier;
+            cmdletResourceInfo.resourceIdentifierType = ResourceIdentifierType.WithGroupTypeName;
+            cmdletResourceInfo.resourceGroup = "cloudsvcrg";
+            cmdletResourceInfo.resourceName = "x123cloudsvc";
+            cmdletResourceInfo.resourceType = "Microsoft.ClassicCompute/domainNames/slots";
+            cmdletParameters.resourceIdentifier = cmdletResourceInfo;
+            cmdletParameters.apiVersion = "2014-04-01";
+            cmdletParameters.isCollection = false; // bug fix
+            throwIfObjectNotEqual(cmdletParameters, resolver.getParameters());
+
+            logSuccess(arguments);
+        }
+
+        function getParametersForResGrpNameResTypeResNameSubType1SubName1() {
+            let resourceDefinition = {} as IResourceDefinition;
+            resourceDefinition.actions = ["GET", "DELETE", "PUT"];
+            resourceDefinition.apiVersion = "2014-04-01";
+            resourceDefinition.children = ["roles"];
+
+            let actions = [] as IAction[];
+            actions[0] = { httpMethod: "DELETE", name: "Delete", url: "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloudsvcrg/providers/Microsoft.ClassicCompute/domainNames/x123cloudsvc/slots/Production", query: undefined, requestBody: undefined };
+
+            let value = {} as ISelectHandlerReturn;
+            value.httpMethod = "GET";
+            value.url = "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloudsvcrg/providers/Microsoft.ClassicCompute/domainNames/x123cloudsvc/slots/Production";
+            value.resourceDefinition = resourceDefinition;
+            let resolver = new PSCmdletParameterResolver(new ARMUrlParser(value, actions));
+            let actualSupportedCommands: Array<RMCommandInfo> = resolver.getSupportedCommands();
+            let expectedSupportedCommands: Array<RMCommandInfo> = [{ cmd: "Get-AzureRmResource", isAction: false, isSetAction: false }, { cmd: "Set-AzureRmResource", isAction: false, isSetAction: true },
+                { cmd: "Remove-AzureRmResource", isAction: true, isSetAction: false }];
+
+            throwIfArrayNotEqual(expectedSupportedCommands, actualSupportedCommands);
+
+            let cmdletParameters = {} as CmdletParameters;
+            let cmdletResourceInfo = {} as ResourceIdentifier;
+            cmdletResourceInfo.resourceIdentifierType = ResourceIdentifierType.WithGroupTypeName;
+            cmdletResourceInfo.resourceGroup = "cloudsvcrg";
+            cmdletResourceInfo.resourceName = "x123cloudsvc/Production";
+            cmdletResourceInfo.resourceType = "Microsoft.ClassicCompute/domainNames/slots";
+            cmdletParameters.resourceIdentifier = cmdletResourceInfo;
+            cmdletParameters.apiVersion = "2014-04-01";
+            cmdletParameters.isCollection = false;
+            throwIfObjectNotEqual(cmdletParameters, resolver.getParameters());
+
+            logSuccess(arguments);
+        }
+
+        function getParametersForResGrpNameResTypeResNameSubType1SubName1SubType2() {
+            let resourceDefinition = {} as IResourceDefinition;
+            resourceDefinition.actions = ["GET", "CREATE"];
+            resourceDefinition.apiVersion = "2014-04-01";
+            resourceDefinition.children = "{name}";
+
+            let value = {} as ISelectHandlerReturn;
+            value.httpMethod = "GET";
+            value.url = "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloudsvcrg/providers/Microsoft.ClassicCompute/domainNames/x123cloudsvc/slots/Production/roles";
+            value.resourceDefinition = resourceDefinition;
+            let resolver = new PSCmdletParameterResolver(new ARMUrlParser(value,[]));
+            let actualSupportedCommands: Array<RMCommandInfo> = resolver.getSupportedCommands();
+            let expectedSupportedCommands: Array<RMCommandInfo> = [{ cmd: "Get-AzureRmResource", isAction: false, isSetAction: false }, { cmd: "New-AzureRmResource", isAction: false, isSetAction: false }];
+
+            throwIfArrayNotEqual(expectedSupportedCommands, actualSupportedCommands);
+
+            let cmdletParameters = {} as CmdletParameters;
+            let cmdletResourceInfo = {} as ResourceIdentifier;
+            cmdletResourceInfo.resourceIdentifierType = ResourceIdentifierType.WithGroupTypeName;
+            cmdletResourceInfo.resourceGroup = "cloudsvcrg";
+            cmdletResourceInfo.resourceName = "x123cloudsvc/Production";
+            cmdletResourceInfo.resourceType = "Microsoft.ClassicCompute/domainNames/slots/roles";
+            cmdletParameters.resourceIdentifier = cmdletResourceInfo;
+            cmdletParameters.apiVersion = "2014-04-01";
+            cmdletParameters.isCollection = false; // bug fix
+            throwIfObjectNotEqual(cmdletParameters, resolver.getParameters());
+
+            logSuccess(arguments);
+        }
+
+        function getParametersForResGrpNameResTypeResNameSubType1SubName1SubType2SubName2() {
+            let resourceDefinition = {} as IResourceDefinition;
+            resourceDefinition.actions = ["GET", "DELETE", "PUT"];
+            resourceDefinition.apiVersion = "2014-04-01";
+            resourceDefinition.children = ["metricDefinitions", "metrics"];
+
+            let actions = [] as IAction[];
+            actions[0] = { httpMethod: "DELETE", name: "Delete", url: "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloudsvcrg/providers/Microsoft.ClassicCompute/domainNames/x123cloudsvc/slots/Production/roles/WorkerRole1", query: undefined, requestBody: undefined };
+
+            let value = {} as ISelectHandlerReturn;
+            value.httpMethod = "GET";
+            value.url = "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloudsvcrg/providers/Microsoft.ClassicCompute/domainNames/x123cloudsvc/slots/Production/roles/WorkerRole1";
+            value.resourceDefinition = resourceDefinition;
+            let resolver = new PSCmdletParameterResolver(new ARMUrlParser(value, actions));
+            let actualSupportedCommands: Array<RMCommandInfo> = resolver.getSupportedCommands();
+            let expectedSupportedCommands: Array<RMCommandInfo> = [{ cmd: "Get-AzureRmResource", isAction: false, isSetAction: false }, { cmd: "Set-AzureRmResource", isAction: false, isSetAction: true },
+                { cmd: "Remove-AzureRmResource", isAction: true, isSetAction: false }];
+
+            throwIfArrayNotEqual(expectedSupportedCommands, actualSupportedCommands);
+
+            let cmdletParameters = {} as CmdletParameters;
+            let cmdletResourceInfo = {} as ResourceIdentifier;
+            cmdletResourceInfo.resourceIdentifierType = ResourceIdentifierType.WithGroupTypeName;
+            cmdletResourceInfo.resourceGroup = "cloudsvcrg";
+            cmdletResourceInfo.resourceName = "x123cloudsvc/Production/WorkerRole1";
+            cmdletResourceInfo.resourceType = "Microsoft.ClassicCompute/domainNames/slots/roles";
+            cmdletParameters.resourceIdentifier = cmdletResourceInfo;
+            cmdletParameters.apiVersion = "2014-04-01";
+            cmdletParameters.isCollection = false;
+            throwIfObjectNotEqual(cmdletParameters, resolver.getParameters());
+
+            logSuccess(arguments);
+        }
+
+        function getParametersForResGrpNameResTypeResNameSubType1SubName1SubType2SubName2SubType3() {
+            let resourceDefinition = {} as IResourceDefinition;
+            resourceDefinition.actions = ["GET", "CREATE"];
+            resourceDefinition.apiVersion = "2014-04-01";
+            resourceDefinition.children = "{name}";
+
+            let value = {} as ISelectHandlerReturn;
+            value.httpMethod = "GET";
+            value.url = "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloudsvcrg/providers/Microsoft.ClassicCompute/domainNames/x123cloudsvc/slots/Production/roles/WorkerRole1/metricDefinitions";
+            value.resourceDefinition = resourceDefinition;
+            let resolver = new PSCmdletParameterResolver(new ARMUrlParser(value,[]));
+            let actualSupportedCommands: Array<RMCommandInfo> = resolver.getSupportedCommands();
+            let expectedSupportedCommands: Array<RMCommandInfo> = [{ cmd: "Get-AzureRmResource", isAction: false, isSetAction: false }, { cmd: "New-AzureRmResource", isAction: false, isSetAction: false }];
+
+            throwIfArrayNotEqual(expectedSupportedCommands, actualSupportedCommands);
+
+            let cmdletParameters = {} as CmdletParameters;
+            let cmdletResourceInfo = {} as ResourceIdentifier;
+            cmdletResourceInfo.resourceIdentifierType = ResourceIdentifierType.WithGroupTypeName;
+            cmdletResourceInfo.resourceGroup = "cloudsvcrg";
+            cmdletResourceInfo.resourceName = "x123cloudsvc/Production/WorkerRole1";
+            cmdletResourceInfo.resourceType = "Microsoft.ClassicCompute/domainNames/slots/roles/metricDefinitions";
+            cmdletParameters.resourceIdentifier = cmdletResourceInfo;
+            cmdletParameters.apiVersion = "2014-04-01";
+            cmdletParameters.isCollection = false; //bug fix
+            throwIfObjectNotEqual(cmdletParameters, resolver.getParameters());
+
+            logSuccess(arguments);
+        }
+
+        function getParametersForResGrpNameResTypeResNameSubType1SubName1SubType2SubName2SubType3SubName3() {
+            let resourceDefinition = {} as IResourceDefinition;
+            resourceDefinition.actions = ["PUT", "GET", "DELETE"];
+            resourceDefinition.apiVersion = "2014-04-01";
+            resourceDefinition.children = "{name}";
+
+            let actions = [] as IAction[];
+            actions[0] = { httpMethod: "DELETE", name: "Delete", url: "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloudsvcrg/providers/Microsoft.ClassicCompute/domainNames/x123cloudsvc/slots/Production/roles/WorkerRole1/metricDefinitions/Percentage CPU", query: undefined, requestBody: undefined };
+
+            let value = {} as ISelectHandlerReturn;
+            value.httpMethod = "GET";
+            value.url = "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloudsvcrg/providers/Microsoft.ClassicCompute/domainNames/x123cloudsvc/slots/Production/roles/WorkerRole1/metricDefinitions/Percentage CPU";
+            value.resourceDefinition = resourceDefinition;
+            let resolver = new PSCmdletParameterResolver(new ARMUrlParser(value, actions));
+            let actualSupportedCommands: Array<RMCommandInfo> = resolver.getSupportedCommands();
+            let expectedSupportedCommands: Array<RMCommandInfo> = [{ cmd: "Get-AzureRmResource", isAction: false, isSetAction: false }, { cmd: "Set-AzureRmResource", isAction: false, isSetAction: true },
+                { cmd: "Remove-AzureRmResource", isAction: true, isSetAction: false }];
+            throwIfArrayNotEqual(expectedSupportedCommands, actualSupportedCommands);
+
+            let cmdletParameters = {} as CmdletParameters;
+            let cmdletResourceInfo = {} as ResourceIdentifier;
+            cmdletResourceInfo.resourceIdentifierType = ResourceIdentifierType.WithGroupTypeName;
+            cmdletResourceInfo.resourceGroup = "cloudsvcrg";
+            cmdletResourceInfo.resourceName = "x123cloudsvc/Production/WorkerRole1/Percentage CPU";
+            cmdletResourceInfo.resourceType = "Microsoft.ClassicCompute/domainNames/slots/roles/metricDefinitions";
+            cmdletParameters.resourceIdentifier = cmdletResourceInfo;
+            cmdletParameters.apiVersion = "2014-04-01";
+            cmdletParameters.isCollection = false;
+            throwIfObjectNotEqual(cmdletParameters, resolver.getParameters());
+
+            logSuccess(arguments);
+        }
+
+        function getParametersForResourceUrlWithList() {
+            let resourceDefinition = {} as IResourceDefinition;
+            resourceDefinition.actions = ["PUT", "GETPOST"];
+            resourceDefinition.apiVersion = "2016-03-01";
+
+            let value = {} as ISelectHandlerReturn;
+            value.httpMethod = "POST";
+            value.url = "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgrp1/providers/Microsoft.Web/sites/WebApp120170517014339/config/appsettings/list";
+            value.resourceDefinition = resourceDefinition;
+            let resolver = new PSCmdletParameterResolver(new ARMUrlParser(value,[]));
+            let scriptor = new PsScriptGenerator(resolver);
+            let actualSupportedCommands: Array<RMCommandInfo> = resolver.getSupportedCommands();
+            let expectedSupportedCommands: Array<RMCommandInfo> = [{ cmd: "Invoke-AzureRmResourceAction", isAction: false, isSetAction: false }, { cmd: "New-AzureRmResource", isAction: false, isSetAction: true }];
+
+            throwIfArrayNotEqual(expectedSupportedCommands, actualSupportedCommands);
+
+            let cmdletParameters = {} as CmdletParameters;
+            let cmdletResourceInfo = {} as ResourceIdentifier;
+            cmdletResourceInfo.resourceIdentifierType = ResourceIdentifierType.WithGroupTypeName;
+            cmdletResourceInfo.resourceGroup = "rgrp1";
+            cmdletResourceInfo.resourceName = "WebApp120170517014339/appsettings";
+            cmdletResourceInfo.resourceType = "Microsoft.Web/sites/config";
+            cmdletParameters.resourceIdentifier = cmdletResourceInfo;
+            cmdletParameters.apiVersion = "2016-03-01";
+            cmdletParameters.isCollection = false;
+            throwIfObjectNotEqual(cmdletParameters, resolver.getParameters());
+
+            logSuccess(arguments);
+        }
+    }
+
+    namespace RMUrlParserTests {
+        parseUrlWithResourceIDOnly();
+        parseUrlWithResouceIDOnlyWithSubId();
+        parseUrlWithResourceIDOnlyWithResourceGroup();
+        parseUrlWithResourceIDOnlyWithResourceGroupName();
+        parseUrlWithResGrpNameResType();
+        parseUrlWithResGrpNameResTypeResName();
+        parseUrlWithResGrpNameResTypeResNameSubType1();
+        parseUrlWithResGrpNameResTypeResNameSubType1SubName1();
+        parseUrlWithResGrpNameResTypeResNameSubType1SubName1SubType2();
+        parseUrlWithResGrpNameResTypeResNameSubType1SubName1SubType2SubName2();
+        parseUrlWithResGrpNameResTypeResNameSubType1SubName1SubType2SubName2SubType3();
+        parseUrlWithResGrpNameResTypeResNameSubType1SubName1SubType2SubName2SubType3SubName3();
+        parseUrlWithResourceUrlWithList();
+
+        function parseUrlWithResourceIDOnly() {
+            let value = {} as ISelectHandlerReturn;
+            value.httpMethod = "GET";
+            value.url = "https://management.azure.com/subscriptions";
+            let parser = new ARMUrlParser(value,[]);
+            let resourceIdentifier: ResourceIdentifier = parser.getResourceIdentifier();
+            throwIfNotEqual(ResourceIdentifierType.WithIDOnly, resourceIdentifier.resourceIdentifierType);
+            throwIfNotEqual("/subscriptions", resourceIdentifier.resourceId);
+            throwIfDefined(resourceIdentifier.resourceName);
+            throwIfDefined(resourceIdentifier.resourceGroup);
+            throwIfDefined(resourceIdentifier.resourceType);
+            logSuccess(arguments);
+        }
+
+        function parseUrlWithResouceIDOnlyWithSubId() {
+            let value = {} as ISelectHandlerReturn;
+            value.httpMethod = "GET";
+            value.url = "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000";
+            let parser = new ARMUrlParser(value,[]);
+            let resourceIdentifier: ResourceIdentifier = parser.getResourceIdentifier();
+            throwIfNotEqual(ResourceIdentifierType.WithIDOnly, resourceIdentifier.resourceIdentifierType);
+            throwIfNotEqual("/subscriptions/00000000-0000-0000-0000-000000000000", resourceIdentifier.resourceId);
+            throwIfDefined(resourceIdentifier.resourceName);
+            throwIfDefined(resourceIdentifier.resourceGroup);
+            throwIfDefined(resourceIdentifier.resourceType);
+            logSuccess(arguments);
+        }
+
+        function parseUrlWithResourceIDOnlyWithResourceGroup() {
+            let value = {} as ISelectHandlerReturn;
+            value.httpMethod = "GET";
+            value.url = "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups";
+            let parser = new ARMUrlParser(value,[]);
+            let resourceIdentifier: ResourceIdentifier = parser.getResourceIdentifier();
+            throwIfNotEqual(ResourceIdentifierType.WithIDOnly, resourceIdentifier.resourceIdentifierType);
+            throwIfNotEqual("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups", resourceIdentifier.resourceId);
+            throwIfDefined(resourceIdentifier.resourceName);
+            throwIfDefined(resourceIdentifier.resourceGroup);
+            throwIfDefined(resourceIdentifier.resourceType);
+            logSuccess(arguments);
+        }
+
+        function parseUrlWithResourceIDOnlyWithResourceGroupName() {
+            let value = {} as ISelectHandlerReturn;
+            value.httpMethod = "GET";
+            value.url = "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloudsvcrg";
+            let parser = new ARMUrlParser(value,[]);
+            let resourceIdentifier: ResourceIdentifier = parser.getResourceIdentifier();
+            throwIfNotEqual(ResourceIdentifierType.WithIDOnly, resourceIdentifier.resourceIdentifierType);
+            throwIfNotEqual("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloudsvcrg", resourceIdentifier.resourceId);
+            throwIfDefined(resourceIdentifier.resourceName);
+            throwIfDefined(resourceIdentifier.resourceGroup);
+            throwIfDefined(resourceIdentifier.resourceType);
+            logSuccess(arguments);
+        }
+
+        function parseUrlWithResGrpNameResType() {
+            let value = {} as ISelectHandlerReturn;
+            value.httpMethod = "GET";
+            value.url = "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloudsvcrg/providers/Microsoft.ClassicCompute/domainNames";
+            let parser = new ARMUrlParser(value,[]);
+            let resourceIdentifier: ResourceIdentifier = parser.getResourceIdentifier();
+            throwIfNotEqual(ResourceIdentifierType.WithGroupType, resourceIdentifier.resourceIdentifierType);
+            throwIfNotEqual("cloudsvcrg", resourceIdentifier.resourceGroup);
+            throwIfNotEqual("Microsoft.ClassicCompute/domainNames", resourceIdentifier.resourceType);
+            throwIfDefined(resourceIdentifier.resourceName);
+            throwIfDefined(resourceIdentifier.resourceId);
+            logSuccess(arguments);
+        }
+
+        function parseUrlWithResGrpNameResTypeResName() {
+            let value = {} as ISelectHandlerReturn;
+            value.httpMethod = "GET";
+            value.url = "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloudsvcrg/providers/Microsoft.ClassicCompute/domainNames/x123cloudsvc";
+            let parser = new ARMUrlParser(value,[]);
+            let resourceIdentifier: ResourceIdentifier = parser.getResourceIdentifier();
+            throwIfNotEqual(ResourceIdentifierType.WithGroupTypeName, resourceIdentifier.resourceIdentifierType);
+            throwIfNotEqual("cloudsvcrg", resourceIdentifier.resourceGroup);
+            throwIfNotEqual("Microsoft.ClassicCompute/domainNames", resourceIdentifier.resourceType);
+            throwIfNotEqual("x123cloudsvc", resourceIdentifier.resourceName);
+            throwIfDefined(resourceIdentifier.resourceId);
+            logSuccess(arguments);
+        }
+
+        function parseUrlWithResGrpNameResTypeResNameSubType1() {
+            let value = {} as ISelectHandlerReturn;
+            value.httpMethod = "GET";
+            value.url = "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloudsvcrg/providers/Microsoft.ClassicCompute/domainNames/x123cloudsvc/slots";
+            let parser = new ARMUrlParser(value,[]);
+            let resourceIdentifier: ResourceIdentifier = parser.getResourceIdentifier();
+            throwIfNotEqual(ResourceIdentifierType.WithGroupTypeName, resourceIdentifier.resourceIdentifierType);
+            throwIfNotEqual("cloudsvcrg", resourceIdentifier.resourceGroup);
+            throwIfNotEqual("Microsoft.ClassicCompute/domainNames/slots", resourceIdentifier.resourceType);
+            throwIfNotEqual("x123cloudsvc", resourceIdentifier.resourceName);
+            throwIfDefined(resourceIdentifier.resourceId);
+            logSuccess(arguments);
+        }
+
+        function parseUrlWithResGrpNameResTypeResNameSubType1SubName1() {
+            let value = {} as ISelectHandlerReturn;
+            value.httpMethod = "GET";
+            value.url = "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloudsvcrg/providers/Microsoft.ClassicCompute/domainNames/x123cloudsvc/slots/Production";
+            let parser = new ARMUrlParser(value,[]);
+            let resourceIdentifier: ResourceIdentifier = parser.getResourceIdentifier();
+            throwIfNotEqual(ResourceIdentifierType.WithGroupTypeName, resourceIdentifier.resourceIdentifierType);
+            throwIfNotEqual("cloudsvcrg", resourceIdentifier.resourceGroup);
+            throwIfNotEqual("Microsoft.ClassicCompute/domainNames/slots", resourceIdentifier.resourceType);
+            throwIfNotEqual("x123cloudsvc/Production", resourceIdentifier.resourceName);
+            throwIfDefined(resourceIdentifier.resourceId);
+            logSuccess(arguments);
+        }
+
+        function parseUrlWithResGrpNameResTypeResNameSubType1SubName1SubType2() {
+            let value = {} as ISelectHandlerReturn;
+            value.httpMethod = "GET";
+            value.url = "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloudsvcrg/providers/Microsoft.ClassicCompute/domainNames/x123cloudsvc/slots/Production/roles";
+            let parser = new ARMUrlParser(value,[]);
+            let resourceIdentifier: ResourceIdentifier = parser.getResourceIdentifier();
+            throwIfNotEqual(ResourceIdentifierType.WithGroupTypeName, resourceIdentifier.resourceIdentifierType);
+            throwIfNotEqual("cloudsvcrg", resourceIdentifier.resourceGroup);
+            throwIfNotEqual("Microsoft.ClassicCompute/domainNames/slots/roles", resourceIdentifier.resourceType);
+            throwIfNotEqual("x123cloudsvc/Production", resourceIdentifier.resourceName);
+            throwIfDefined(resourceIdentifier.resourceId);
+            logSuccess(arguments);
+        }
+
+        function parseUrlWithResGrpNameResTypeResNameSubType1SubName1SubType2SubName2() {
+            let value = {} as ISelectHandlerReturn;
+            value.httpMethod = "GET";
+            value.url = "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloudsvcrg/providers/Microsoft.ClassicCompute/domainNames/x123cloudsvc/slots/Production/roles/WorkerRole1";
+            let parser = new ARMUrlParser(value,[]);
+            let resourceIdentifier: ResourceIdentifier = parser.getResourceIdentifier();
+            throwIfNotEqual(ResourceIdentifierType.WithGroupTypeName, resourceIdentifier.resourceIdentifierType);
+            throwIfNotEqual("cloudsvcrg", resourceIdentifier.resourceGroup);
+            throwIfNotEqual("Microsoft.ClassicCompute/domainNames/slots/roles", resourceIdentifier.resourceType);
+            throwIfNotEqual("x123cloudsvc/Production/WorkerRole1", resourceIdentifier.resourceName);
+            throwIfDefined(resourceIdentifier.resourceId);
+            logSuccess(arguments);
+        }
+
+        function parseUrlWithResGrpNameResTypeResNameSubType1SubName1SubType2SubName2SubType3() {
+            let value = {} as ISelectHandlerReturn;
+            value.httpMethod = "GET";
+            value.url = "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloudsvcrg/providers/Microsoft.ClassicCompute/domainNames/x123cloudsvc/slots/Production/roles/WorkerRole1/metricDefinitions";
+            let parser = new ARMUrlParser(value,[]);
+            let resourceIdentifier: ResourceIdentifier = parser.getResourceIdentifier();
+            throwIfNotEqual(ResourceIdentifierType.WithGroupTypeName, resourceIdentifier.resourceIdentifierType);
+            throwIfNotEqual("cloudsvcrg", resourceIdentifier.resourceGroup);
+            throwIfNotEqual("Microsoft.ClassicCompute/domainNames/slots/roles/metricDefinitions", resourceIdentifier.resourceType);
+            throwIfNotEqual("x123cloudsvc/Production/WorkerRole1", resourceIdentifier.resourceName);
+            throwIfDefined(resourceIdentifier.resourceId);
+            logSuccess(arguments);
+        }
+
+        function parseUrlWithResGrpNameResTypeResNameSubType1SubName1SubType2SubName2SubType3SubName3() {
+            let value = {} as ISelectHandlerReturn;
+            value.httpMethod = "GET";
+            value.url = "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloudsvcrg/providers/Microsoft.ClassicCompute/domainNames/x123cloudsvc/slots/Production/roles/WorkerRole1/metricDefinitions/Percentage CPU";
+            let parser = new ARMUrlParser(value,[]);
+            let resourceIdentifier: ResourceIdentifier = parser.getResourceIdentifier();
+            throwIfNotEqual(ResourceIdentifierType.WithGroupTypeName, resourceIdentifier.resourceIdentifierType);
+            throwIfNotEqual("cloudsvcrg", resourceIdentifier.resourceGroup);
+            throwIfNotEqual("Microsoft.ClassicCompute/domainNames/slots/roles/metricDefinitions", resourceIdentifier.resourceType);
+            throwIfNotEqual("x123cloudsvc/Production/WorkerRole1/Percentage CPU", resourceIdentifier.resourceName);
+            throwIfDefined(resourceIdentifier.resourceId);
+            logSuccess(arguments);
+        }
+
+        function parseUrlWithResourceUrlWithList() {
+            let value = {} as ISelectHandlerReturn;
+            value.httpMethod = "POST";
+            value.url = "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgrp1/providers/Microsoft.Web/sites/WebApp120170517014339/config/appsettings/list";
+            let parser = new ARMUrlParser(value,[]);
+            let resourceIdentifier: ResourceIdentifier = parser.getResourceIdentifier();
+            throwIfNotEqual(ResourceIdentifierType.WithGroupTypeName, resourceIdentifier.resourceIdentifierType);
+            throwIfNotEqual("rgrp1", resourceIdentifier.resourceGroup);
+            throwIfNotEqual("Microsoft.Web/sites/config", resourceIdentifier.resourceType);
+            throwIfNotEqual("WebApp120170517014339/appsettings", resourceIdentifier.resourceName);
+            throwIfDefined(resourceIdentifier.resourceId);
+            logSuccess(arguments);
+        }
+    }
+}

--- a/ng/tsconfig.json
+++ b/ng/tsconfig.json
@@ -1,0 +1,35 @@
+{
+    "compilerOptions": {
+        "noImplicitAny": false,
+        "removeComments": false,
+        "preserveConstEnums": true,
+        "sourceMap": false,
+        "outFile": "manageWithTests.js",
+        "listFiles": false
+    },
+        "files": [
+        "PowerShellScriptGenerator.ts",
+        "models/IAction.ts",
+        "models/IArmTreeScope.ts",
+        "models/IMetadataObject.ts",
+        "models/IResourceDefinition.ts",
+        "models/IResourceSearch.ts",
+        "models/ISelectHandlerReturn.ts",
+        "models/ITenantDetails.ts",
+        "models/ITreeBranch.ts",
+        "models/ITreeControl.ts",
+        "polyfill.ts",
+        "typings/ace/ace.d.ts",
+        "typings/angularjs/angular-animate.d.ts",
+        "typings/angularjs/angular-cookies.d.ts",
+        "typings/angularjs/angular-mocks.d.ts",
+        "typings/angularjs/angular-resource.d.ts",
+        "typings/angularjs/angular-route.d.ts",
+        "typings/angularjs/angular-sanitize.d.ts",
+        "typings/angularjs/angular.d.ts",
+        "typings/cryptojs/cryptojs.d.ts",
+        "typings/jquery.cookie/jquery.cookie.d.ts",
+        "typings/jquery/jquery.d.ts",
+        "test/PowerShellScriptTests.ts"
+    ]
+}


### PR DESCRIPTION
Use New-AzureRmResourceGroup instead of New-AzureRmResource when creating new resource groups. Use -IsCollection flag only if resource name is empty. Fix duplicate -ResourceName parameter for RM cmdlets operating on named resources by using the format name_of_res_to_modify/name_for_new_resource_being_added.